### PR TITLE
Add documentation for global installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,15 @@ Command line utility to synchronize and version control relational database obje
 
     $ yarn add @leapfrogtechnology/sync-db
 
-Install node database driver(s) of the database(s) that are to be synced in your project, for example this is how you would install the mssql driver:
-
-    $ yarn add mssql
-
-### Global
+**Global Installation**
 
     $ yarn global add @leapfrogtechnology/sync-db
 
-Install node database driver(s) of the database(s) that are to be synced globally, for example this is how you would install the mssql driver:
+Install node database driver(s) of the database(s) that are to be synced, for example this is how you would install the mssql driver:
 
-    $ yarn global add mssql
+    $ yarn add mssql
+
+**Note: If sync-db is installed globally, install database driver(s) globally too.**
 
 ## Configure Database Connections
 
@@ -147,12 +145,6 @@ npm install -g npx
 
 ```
 npx sync-db
-```
-
-## Installed Globally
-
-```
-sync-db
 ```
 
 # Sample Projects

--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ Install node database driver(s) of the database(s) that are to be synced in your
 
     $ yarn add mssql
 
-### Configure Database Connections
+### Global
+
+    $ yarn global add @leapfrogtechnology/sync-db
+
+Install node database driver(s) of the database(s) that are to be synced globally, for example this is how you would install the mssql driver:
+
+    $ yarn global add mssql
+
+## Configure Database Connections
 
 Create `connections-sync-db.json` in your project folder and configure your database connection(s) to be synced.
 
@@ -110,6 +118,9 @@ sql:
 
 Add `sync-db` script in your `package.json` file.
 
+## Add sync-db script in package json
+
+1. Add script in your `package.json`
 ```json
 {
   "scripts": {
@@ -118,13 +129,33 @@ Add `sync-db` script in your `package.json` file.
 }
 ```
 
-Run
+2. Run
 
 ```bash
 $ yarn sync-db
 ```
 
-## Sample Projects
+## Use npx
+
+1. Install npx globally on your machine
+
+```
+npm install -g npx
+```
+
+2. Run
+
+```
+npx sync-db
+```
+
+## Installed Globally
+
+```
+sync-db
+```
+
+# Sample Projects
 
 1. [Node MSSQL Sample (JavaScript)](examples/node-app-mssql)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install node database driver(s) of the database(s) that are to be synced, for ex
 
 **Note: If sync-db is installed globally, install database driver(s) globally too.**
 
-## Configure Database Connections
+### Configure Database Connections
 
 Create `connections-sync-db.json` in your project folder and configure your database connection(s) to be synced.
 
@@ -116,7 +116,7 @@ sql:
 
 Add `sync-db` script in your `package.json` file.
 
-## Add sync-db script in package json
+### Add sync-db script in package.json
 
 1. Add script in your `package.json`
 ```json
@@ -133,7 +133,7 @@ Add `sync-db` script in your `package.json` file.
 $ yarn sync-db
 ```
 
-## Use npx
+### Usage with npx
 
 1. Install npx globally on your machine
 
@@ -147,7 +147,7 @@ npm install -g npx
 npx sync-db
 ```
 
-# Sample Projects
+## Sample Projects
 
 1. [Node MSSQL Sample (JavaScript)](examples/node-app-mssql)
 


### PR DESCRIPTION
Add documentation of the following:
- Global Installation of sync-db
- Running sync-db through ngx
- Running sync-db when installed globally.