### PR TITLE
Config Injection - ability to inject dynamic configurations such that the running SQL transactions could access them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-experimental.8-4",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "build": "rm -rf lib && tsc -b",
     "codecov": "codecov",
     "prepack": "yarn build",
+    "lint": "tslint -c tslint.json 'src/**/*.{ts,js}' 'test/**/*.{ts,js}'",
+    "lint:fix": "tslint --fix -c tslint.json 'src/**/*.{ts,js}' 'test/**/*.{ts,js}'",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "test:coverage": "nyc mocha --forbid-only \"test/**/*.test.ts\"",
     "watch": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.0.0-experimental.8-4",
+  "version": "1.0.0-alpha.8",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -82,6 +82,16 @@ class Connection {
   }
 
   /**
+   * Gets access to the schema builder.
+   *
+   * @returns {Knex.SchemaBuilder}
+   * @memberof Connection
+   */
+  public schema(): Knex.SchemaBuilder {
+    return this.instance.schema;
+  }
+
+  /**
    * Returns connection config.
    *
    * @returns {ConnectionConfig}

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -94,7 +94,6 @@ class Connection {
    * Gets access to the schema builder.
    *
    * @returns {Knex.SchemaBuilder}
-   * @memberof Connection
    */
   public schema(): Knex.SchemaBuilder {
     return this.instance.schema;

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -82,6 +82,15 @@ class Connection {
   }
 
   /**
+   * Returns the underlying Knex instance.
+   *
+   * @returns {Knex}
+   */
+  public getInstance(): Knex {
+    return this.instance;
+  }
+
+  /**
    * Gets access to the schema builder.
    *
    * @returns {Knex.SchemaBuilder}

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,8 @@ import * as fs from './util/fs';
 import DbConfig from './domain/DbConfig';
 import SyncConfig from './domain/SyncConfig';
 import ConnectionConfig from './domain/ConnectionConfig';
-import { DEFAULT_CONFIG, CONFIG_FILENAME, CONNECTIONS_FILENAME, ENV_KEYS } from './constants';
 import { prepareInjectionConfigVars } from './services/configInjection';
+import { DEFAULT_CONFIG, CONFIG_FILENAME, CONNECTIONS_FILENAME, ENV_KEYS } from './constants';
 
 /**
  * Load config yaml file.
@@ -25,7 +25,7 @@ export async function loadConfig(): Promise<SyncConfig> {
 
   const loaded = mergeDeepRight(DEFAULT_CONFIG, loadedConfig) as SyncConfig;
 
-  // TODO: Validate the loaded config.
+  validate(loaded);
 
   return {
     ...loaded,
@@ -34,6 +34,17 @@ export async function loadConfig(): Promise<SyncConfig> {
       vars: prepareInjectionConfigVars(loaded.injectedConfig.vars)
     }
   };
+}
+
+/**
+ * Validate the loaded configuration.
+ * TODO: IMPLEMENT THIS.
+ *
+ * @param {SyncConfig} config
+ */
+function validate(config: SyncConfig) {
+  // TODO: Validate the loaded config.
+  // Throw error if validation fails.
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,7 +51,7 @@ function validate(config: SyncConfig) {
   }
 
   // Shouldn't reach under here unless the user has mismatched the value.
-  if (!injectedConfig.vars || isObject(injectedConfig.vars)) {
+  if (!injectedConfig.vars || !isObject(injectedConfig.vars)) {
     throw new Error('Invalid configuration value for `injectedConfig.vars`.');
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,11 @@ import { mergeDeepRight } from 'ramda';
 
 import { log } from './logger';
 import * as fs from './util/fs';
-import Mapping from './domain/Mapping';
 import DbConfig from './domain/DbConfig';
 import SyncConfig from './domain/SyncConfig';
 import ConnectionConfig from './domain/ConnectionConfig';
 import { DEFAULT_CONFIG, CONFIG_FILENAME, CONNECTIONS_FILENAME, ENV_KEYS } from './constants';
+import { prepareInjectionConfigVars } from './services/configInjection';
 
 /**
  * Load config yaml file.
@@ -31,14 +31,9 @@ export async function loadConfig(): Promise<SyncConfig> {
     ...loaded,
     injectedConfig: {
       ...loaded.injectedConfig,
-      variables: updateInjectedConfigVars(loaded.injectedConfig.variables)
+      vars: prepareInjectionConfigVars(loaded.injectedConfig.vars)
     }
   };
-}
-
-function updateInjectedConfigVars(vars: Mapping<string>): Mapping<string> {
-  // TODO: Implement this.
-  return { ...vars };
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,11 +46,6 @@ export function validate(config: SyncConfig) {
   const { injectedConfig } = config;
 
   // Shouldn't reach under here unless the user has mismatched the value.
-  if (!injectedConfig.table || !injectedConfig.table.trim()) {
-    throw new Error('Invalid configuration value for `injectedConfig.table`.');
-  }
-
-  // Shouldn't reach under here unless the user has mismatched the value.
   if (!injectedConfig.vars || !isObject(injectedConfig.vars)) {
     throw new Error('Invalid configuration value for `injectedConfig.vars`.');
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ export async function loadConfig(): Promise<SyncConfig> {
  *
  * @param {SyncConfig} config
  */
-function validate(config: SyncConfig) {
+export function validate(config: SyncConfig) {
   const { injectedConfig } = config;
 
   // Shouldn't reach under here unless the user has mismatched the value.

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,11 +18,11 @@ export async function loadConfig(): Promise<SyncConfig> {
   log('Resolving sync config file.');
 
   const filename = path.resolve(process.cwd(), CONFIG_FILENAME);
-  const migrations = await yaml.load(filename) as SyncConfig;
+  const loadedConfig = (await yaml.load(filename)) as SyncConfig;
 
   log('Resolved sync config file.');
 
-  const loaded = mergeDeepRight(DEFAULT_CONFIG, migrations) as SyncConfig;
+  const loaded = mergeDeepRight(DEFAULT_CONFIG, loadedConfig) as SyncConfig;
 
   // TODO: Validate the loaded config.
 
@@ -50,7 +50,10 @@ export async function resolveConnections(): Promise<ConnectionConfig[]> {
     id: connection.id || `${connection.host}/${connection.database}`
   }));
 
-  log('Resolved connections: %O', result.map(({ id, host, database }) => ({ id, host, database })));
+  log(
+    'Resolved connections: %O',
+    result.map(({ id, host, database }) => ({ id, host, database }))
+  );
 
   return result;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { mergeDeepRight } from 'ramda';
 
 import { log } from './logger';
 import * as fs from './util/fs';
+import Mapping from './domain/Mapping';
 import DbConfig from './domain/DbConfig';
 import SyncConfig from './domain/SyncConfig';
 import ConnectionConfig from './domain/ConnectionConfig';
@@ -26,7 +27,18 @@ export async function loadConfig(): Promise<SyncConfig> {
 
   // TODO: Validate the loaded config.
 
-  return loaded;
+  return {
+    ...loaded,
+    injectedConfig: {
+      ...loaded.injectedConfig,
+      variables: updateInjectedConfigVars(loaded.injectedConfig.variables)
+    }
+  };
+}
+
+function updateInjectedConfigVars(vars: Mapping<string>): Mapping<string> {
+  // TODO: Implement this.
+  return { ...vars };
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,12 +38,23 @@ export async function loadConfig(): Promise<SyncConfig> {
 
 /**
  * Validate the loaded configuration.
- * TODO: IMPLEMENT THIS.
  *
  * @param {SyncConfig} config
  */
 function validate(config: SyncConfig) {
-  // TODO: Validate the loaded config.
+  const { injectedConfig } = config;
+
+  // Shouldn't reach under here unless the user has mismatched the value.
+  if (!injectedConfig.table || !injectedConfig.table.trim()) {
+    throw new Error('Invalid configuration value for `injectedConfig.table`.');
+  }
+
+  // Shouldn't reach under here unless the user has mismatched the value.
+  if (!injectedConfig.vars || isObject(injectedConfig.vars)) {
+    throw new Error('Invalid configuration value for `injectedConfig.vars`.');
+  }
+
+  // TODO: Validate the remaining loaded config.
   // Throw error if validation fails.
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { mergeDeepRight } from 'ramda';
 
 import { log } from './logger';
 import * as fs from './util/fs';
+import { isObject } from './util/types';
 import DbConfig from './domain/DbConfig';
 import SyncConfig from './domain/SyncConfig';
 import ConnectionConfig from './domain/ConnectionConfig';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,7 +16,7 @@ export const DEFAULT_CONFIG: SyncConfig = {
   },
   injectedConfig: {
     table: '__injected_config',
-    variables: {}
+    vars: {}
   }
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,10 @@ export const DEFAULT_CONFIG: SyncConfig = {
   hooks: {
     pre_sync: [],
     post_sync: []
+  },
+  injectedConfig: {
+    table: '__injected_config',
+    variables: {}
   }
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ import SyncConfig from './domain/SyncConfig';
 export const CONFIG_FILENAME = 'sync-db.yml';
 export const CONNECTIONS_FILENAME = 'connections.sync-db.json';
 
-export const INJECTED_CONFIG_TABLE = '__injected_config';
+export const INJECTED_CONFIG_TABLE = '__sync_db_injected_config';
 export const DEFAULT_CONFIG: SyncConfig = {
   basePath: path.resolve(process.cwd(), 'src/sql'),
   sql: [],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ import SyncConfig from './domain/SyncConfig';
 export const CONFIG_FILENAME = 'sync-db.yml';
 export const CONNECTIONS_FILENAME = 'connections.sync-db.json';
 
+export const INJECTED_CONFIG_TABLE = '__injected_config';
 export const DEFAULT_CONFIG: SyncConfig = {
   basePath: path.resolve(process.cwd(), 'src/sql'),
   sql: [],
@@ -15,7 +16,6 @@ export const DEFAULT_CONFIG: SyncConfig = {
     post_sync: []
   },
   injectedConfig: {
-    table: '__injected_config',
     vars: {}
   }
 };

--- a/src/domain/KeyValuePair.ts
+++ b/src/domain/KeyValuePair.ts
@@ -1,0 +1,9 @@
+/**
+ * A simple key / value pair interface.
+ */
+interface KeyValuePair {
+  key: string;
+  value: string;
+}
+
+export default KeyValuePair;

--- a/src/domain/SyncConfig.ts
+++ b/src/domain/SyncConfig.ts
@@ -12,7 +12,7 @@ interface SyncConfig {
   };
   injectedConfig: {
     table: string;
-    variables: Mapping<string>;
+    vars: Mapping<string>;
   };
 }
 

--- a/src/domain/SyncConfig.ts
+++ b/src/domain/SyncConfig.ts
@@ -1,3 +1,5 @@
+import Mapping from './Mapping';
+
 /**
  * Interface for synchronization configuration sycn-db.yml.
  */
@@ -7,6 +9,10 @@ interface SyncConfig {
   hooks: {
     pre_sync: string[];
     post_sync: string[];
+  };
+  injectedConfig: {
+    table: string;
+    values: Mapping<string>;
   };
 }
 

--- a/src/domain/SyncConfig.ts
+++ b/src/domain/SyncConfig.ts
@@ -11,7 +11,6 @@ interface SyncConfig {
     post_sync: string[];
   };
   injectedConfig: {
-    table: string;
     vars: Mapping<string>;
   };
 }

--- a/src/domain/SyncConfig.ts
+++ b/src/domain/SyncConfig.ts
@@ -12,7 +12,7 @@ interface SyncConfig {
   };
   injectedConfig: {
     table: string;
-    values: Mapping<string>;
+    variables: Mapping<string>;
   };
 }
 

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -27,9 +27,9 @@ export function setup(config: SyncConfig): (connection: Connection) => Promise<v
     const { pre_sync: preMigrationScripts, post_sync: postMigrationScripts } = hooks;
 
     await connection.transaction(async t => {
-      // Setup - Config Injection .
+      // Config Injection: Setup
       // This will setup a config table (temporary and accessible only to this transaction).
-      configInjection.setup(t, config);
+      await configInjection.setup(t, config);
 
       if (preMigrationScripts.length > 0) {
         const preHookScripts = await sqlRunner.resolveFiles(basePath, preMigrationScripts);
@@ -52,9 +52,9 @@ export function setup(config: SyncConfig): (connection: Connection) => Promise<v
         logDb('POST-SYNC: End');
       }
 
-      // Clean up - Config Injection.
+      // Config Injection: Cleanup
       // Cleans up the injected config and the table.
-      configInjection.cleanup(t, config);
+      await configInjection.cleanup(t, config);
 
       logDb('Finished setup');
     });

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -89,8 +89,22 @@ export async function synchronize(
 ) {
   log('Starting to synchronize.');
   const connArr = Array.isArray(conn) ? conn : [conn];
+  const connections = mapToConnectionInstances(connArr);
+  const promises = connections.map(connection => syncDatabase(connection, config));
 
-  const connections = connArr.map(con => {
+  await Promise.all(promises);
+
+  log('All synchronized');
+}
+
+/**
+ * Map connection configuration list to the connection instances.
+ *
+ * @param {((ConnectionConfig | Knex)[])} connectionList
+ * @returns {Connection[]}
+ */
+function mapToConnectionInstances(connectionList: (ConnectionConfig | Knex)[]): Connection[] {
+  return connectionList.map(con => {
     if (Connection.isKnexInstance(con)) {
       log(`Received connection instance to database: ${con.client.config.connection.database}`);
 
@@ -101,12 +115,6 @@ export async function synchronize(
 
     return new Connection(con);
   });
-
-  const promises = connections.map(connection => syncDatabase(connection, config));
-
-  await Promise.all(promises);
-
-  log('All synchronized');
 }
 
 /**

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -26,7 +26,7 @@ function getDefaultSystemVars(): Mapping<string> {
  * @returns {Mapping<string>}
  */
 export function prepareInjectionConfigVars(vars: Mapping<string>): Mapping<string> {
-  return updateInjectedConfigVars({ ...vars, ...getDefaultSystemVars() });
+  return expandEnvVariables({ ...vars, ...getDefaultSystemVars() });
 }
 
 /**
@@ -36,7 +36,7 @@ export function prepareInjectionConfigVars(vars: Mapping<string>): Mapping<strin
  * @param {Mapping<string>} vars
  * @returns {Mapping<string>}
  */
-export function updateInjectedConfigVars(vars: Mapping<string>): Mapping<string> {
+export function expandEnvVariables(vars: Mapping<string>): Mapping<string> {
   const entries = Object.entries(vars);
   const result = entries.reduce(
     (acc, entry) => Object.assign({}, acc, { [entry[0]]: expandEnvVars(entry[1]) }) as Mapping<string>,

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,0 +1,18 @@
+import Mapping from '../domain/Mapping';
+
+/**
+ * Update variables to be injected and expand
+ * environment variables to be expanded.
+ *
+ * @param {Mapping<string>} vars
+ * @returns {Mapping<string>}
+ */
+export function updateInjectedConfigVars(vars: Mapping<string>): Mapping<string> {
+  const entries = Object.entries(vars);
+  const result = entries.reduce(
+    (acc, entry) => Object.assign({}, acc, { [entry[0]]: entry[1] }) as Mapping<string>,
+    {} as Mapping<string>
+  );
+
+  return result;
+}

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -58,16 +58,16 @@ export function convertToKeyValuePairs(vars: Mapping<string>): KeyValuePair[] {
  * @returns {Promise<void>}
  */
 export async function setup(connection: Connection, config: SyncConfig): Promise<void> {
-  const logDb = dbLogger(connection);
+  const log = dbLogger(connection);
   const { injectedConfig } = config;
 
-  logDb(`Making sure table ${INJECTED_CONFIG_TABLE} doesn't already exists.`);
+  log(`Making sure table ${INJECTED_CONFIG_TABLE} doesn't already exists.`);
 
   const exists = await connection.schema().hasTable(INJECTED_CONFIG_TABLE);
 
   // TODO: Think about a better solution; it shouldn't have existed in the first place.
   if (exists) {
-    logDb('Warning: Table "${INJECTED_CONFIG_TABLE}" already exists. It will be dropped.');
+    log('Warning: Table "${INJECTED_CONFIG_TABLE}" already exists. It will be dropped.');
 
     await cleanup(connection, config);
   }
@@ -75,20 +75,20 @@ export async function setup(connection: Connection, config: SyncConfig): Promise
   const values = convertToKeyValuePairs(injectedConfig.vars);
 
   // Create table
-  logDb(`Creating table ${INJECTED_CONFIG_TABLE}.`);
+  log(`Creating table ${INJECTED_CONFIG_TABLE}.`);
   await connection.schema().createTable(INJECTED_CONFIG_TABLE, table => {
     table.string('key').primary();
     table.string('value');
   });
 
   // Inject the configurations into the created table.
-  logDb(`Injecting config into ${INJECTED_CONFIG_TABLE}.`);
+  log(`Injecting config into ${INJECTED_CONFIG_TABLE}.`);
   await connection
     .getInstance()
     .insert(values)
     .into(INJECTED_CONFIG_TABLE);
 
-  logDb(`Inserted configurations: ${values.length}.`);
+  log(`Injected ${values.length} configurations.`);
 }
 
 /**
@@ -99,9 +99,9 @@ export async function setup(connection: Connection, config: SyncConfig): Promise
  * @returns {Promise<void>}
  */
 export async function cleanup(connection: Connection, config: SyncConfig): Promise<void> {
-  const logDb = dbLogger(connection);
+  const log = dbLogger(connection);
 
   await connection.schema().dropTableIfExists(INJECTED_CONFIG_TABLE);
 
-  logDb(`Cleaned up table ${INJECTED_CONFIG_TABLE}.`);
+  log(`Cleaned up table ${INJECTED_CONFIG_TABLE}.`);
 }

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -57,8 +57,9 @@ export function convertToKeyValuePairs(vars: Mapping<string>): KeyValuePair[] {
  *
  * @param {Connection} connection
  * @param {SyncConfig} config
+ * @returns {Promise<void>}
  */
-export async function setup(connection: Connection, config: SyncConfig) {
+export async function setup(connection: Connection, config: SyncConfig): Promise<void> {
   const logDb = dbLogger(connection);
   const { injectedConfig } = config;
 
@@ -66,8 +67,11 @@ export async function setup(connection: Connection, config: SyncConfig) {
 
   const exists = await connection.schema().hasTable(injectedConfig.table);
 
+  // TODO: Think about a better solution; it shouldn't hav existed in the first place.
   if (exists) {
-    throw new Error(`Table "${injectedConfig.table}" already exists.`);
+    logDb('Warning: Table "${injectedConfig.table}" already exists. It will be dropped.');
+
+    await cleanup(connection, config);
   }
 
   const values = convertToKeyValuePairs(injectedConfig.vars);
@@ -94,8 +98,9 @@ export async function setup(connection: Connection, config: SyncConfig) {
  *
  * @param {Connection} connection
  * @param {SyncConfig} config
+ * @returns {Promise<void>}
  */
-export async function cleanup(connection: Connection, config: SyncConfig) {
+export async function cleanup(connection: Connection, config: SyncConfig): Promise<void> {
   const logDb = dbLogger(connection);
 
   await connection.schema().dropTableIfExists(config.injectedConfig.table);

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,4 +1,5 @@
 import Mapping from '../domain/Mapping';
+import { expandEnvVars } from '../util/env';
 
 /**
  * Update variables to be injected and expand
@@ -10,7 +11,7 @@ import Mapping from '../domain/Mapping';
 export function updateInjectedConfigVars(vars: Mapping<string>): Mapping<string> {
   const entries = Object.entries(vars);
   const result = entries.reduce(
-    (acc, entry) => Object.assign({}, acc, { [entry[0]]: entry[1] }) as Mapping<string>,
+    (acc, entry) => Object.assign({}, acc, { [entry[0]]: expandEnvVars(entry[1]) }) as Mapping<string>,
     {} as Mapping<string>
   );
 

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,7 +1,7 @@
 import Mapping from '../domain/Mapping';
 import { expandEnvVars } from '../util/env';
 
-import * as pkg from '../../package.json';
+import { version as syncDbVersion } from '../../package.json';
 
 /**
  * Gets all the default config / environment variables
@@ -11,7 +11,7 @@ import * as pkg from '../../package.json';
  */
 function getDefaultSystemVars(): Mapping<string> {
   return {
-    sync_db_version: pkg.version
+    sync_db_version: syncDbVersion
   };
 }
 

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,6 +1,10 @@
 import Mapping from '../domain/Mapping';
 import { expandEnvVars } from '../util/env';
 
+import Connection from '../Connection';
+import SyncConfig from '../domain/SyncConfig';
+import KeyValuePair from '../domain/KeyValuePair';
+
 import { version as syncDbVersion } from '../../package.json';
 
 /**
@@ -40,4 +44,14 @@ export function updateInjectedConfigVars(vars: Mapping<string>): Mapping<string>
   );
 
   return result;
+}
+
+/**
+ * Convert an object (map of key => value) into an array of key / value pairs.
+ *
+ * @param {Mapping<string>} vars
+ * @returns {KeyValuePair[]}
+ */
+export function convertToKeyValuePairs(vars: Mapping<string>): KeyValuePair[] {
+  return Object.entries(vars).map(([key, value]) => ({ key, value }));
 }

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -45,7 +45,7 @@ export function convertToKeyValuePairs(vars: Mapping<string>): KeyValuePair[] {
  * @param {Connection} connection
  * @param {SyncConfig} config
  */
-export async function setupTable(connection: Connection, config: SyncConfig) {
+export async function setup(connection: Connection, config: SyncConfig) {
   const { injectedConfig } = config;
 
   const exists = await connection.schema().hasTable(injectedConfig.table);
@@ -73,6 +73,6 @@ export async function setupTable(connection: Connection, config: SyncConfig) {
  * @param {Connection} connection
  * @param {SyncConfig} config
  */
-export async function dropTable(connection: Connection, config: SyncConfig) {
+export async function cleanup(connection: Connection, config: SyncConfig) {
   await connection.schema().dropTableIfExists(config.injectedConfig.table);
 }

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,3 +1,7 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { dbLogger } from '../logger';
 import Mapping from '../domain/Mapping';
 import { expandEnvVarsInMap } from '../util/env';
 
@@ -5,8 +9,14 @@ import Connection from '../Connection';
 import SyncConfig from '../domain/SyncConfig';
 import KeyValuePair from '../domain/KeyValuePair';
 
-import { dbLogger } from '../logger';
-import { version as syncDbVersion } from '../../package.json';
+/**
+ * Reads and returns the package.json contents.
+ *
+ * @returns {*}
+ */
+export function getPackageMetadata(): any {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json')).toString());
+}
 
 /**
  * Gets all the default config / environment variables
@@ -15,8 +25,10 @@ import { version as syncDbVersion } from '../../package.json';
  * @returns {Mapping<string>}
  */
 function getDefaultSystemVars(): Mapping<string> {
+  const { version } = getPackageMetadata();
+
   return {
-    sync_db_version: syncDbVersion
+    sync_db_version: version
   };
 }
 

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,6 +1,30 @@
 import Mapping from '../domain/Mapping';
 import { expandEnvVars } from '../util/env';
 
+import * as pkg from '../../package.json';
+
+/**
+ * Gets all the default config / environment variables
+ * that are always available in the injected config table.
+ *
+ * @returns {Mapping<string>}
+ */
+function getDefaultSystemVars(): Mapping<string> {
+  return {
+    sync_db_version: pkg.version
+  };
+}
+
+/**
+ * Prepares config vars for injecting into the target database.
+ *
+ * @param {Mapping<string>} vars
+ * @returns {Mapping<string>}
+ */
+export function prepareInjectionConfigVars(vars: Mapping<string>): Mapping<string> {
+  return updateInjectedConfigVars({ ...vars, ...getDefaultSystemVars() });
+}
+
 /**
  * Update variables to be injected and expand
  * environment variables to be expanded.

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,7 +1,5 @@
 import Mapping from '../domain/Mapping';
 
-const REGEX_VAR_EXPANSION = /\$\{([a-zA-Z]\w+)\}/g;
-
 /**
  * Update variables to be injected and expand
  * environment variables to be expanded.
@@ -17,21 +15,4 @@ export function updateInjectedConfigVars(vars: Mapping<string>): Mapping<string>
   );
 
   return result;
-}
-
-/**
- * Expands the environment variables present in the string.
- * Returns the string as is, if no variables were present. And,
- * in case the variable used in the string isn't defined it is
- * substituted with an empty string ('').
- *
- *  Example:
- *    Input: 'Current user is ${USER} at ${HOST}.'
- *    Output: 'Current user is kabir at leapfrog.'
- *
- * @param {string} value
- * @returns {string}
- */
-export function expandEnvVar(value: string): string {
-  return value.replace(REGEX_VAR_EXPANSION, (_, key) => process.env[key] || '');
 }

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,5 +1,7 @@
 import Mapping from '../domain/Mapping';
 
+const REGEX_VAR_EXPANSION = /\$\{([a-zA-Z]\w+)\}/g;
+
 /**
  * Update variables to be injected and expand
  * environment variables to be expanded.
@@ -15,4 +17,21 @@ export function updateInjectedConfigVars(vars: Mapping<string>): Mapping<string>
   );
 
   return result;
+}
+
+/**
+ * Expands the environment variables present in the string.
+ * Returns the string as is, if no variables were present. And,
+ * in case the variable used in the string isn't defined it is
+ * substituted with an empty string ('').
+ *
+ *  Example:
+ *    Input: 'Current user is ${USER} at ${HOST}.'
+ *    Output: 'Current user is kabir at leapfrog.'
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function expandEnvVar(value: string): string {
+  return value.replace(REGEX_VAR_EXPANSION, (_, key) => process.env[key] || '');
 }

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -67,7 +67,7 @@ export async function setup(connection: Connection, config: SyncConfig): Promise
 
   const exists = await connection.schema().hasTable(injectedConfig.table);
 
-  // TODO: Think about a better solution; it shouldn't hav existed in the first place.
+  // TODO: Think about a better solution; it shouldn't have existed in the first place.
   if (exists) {
     logDb('Warning: Table "${injectedConfig.table}" already exists. It will be dropped.');
 

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -1,5 +1,5 @@
 import Mapping from '../domain/Mapping';
-import { expandEnvVars } from '../util/env';
+import { expandEnvVarsInMap } from '../util/env';
 
 import Connection from '../Connection';
 import SyncConfig from '../domain/SyncConfig';
@@ -26,24 +26,7 @@ function getDefaultSystemVars(): Mapping<string> {
  * @returns {Mapping<string>}
  */
 export function prepareInjectionConfigVars(vars: Mapping<string>): Mapping<string> {
-  return expandEnvVariables({ ...vars, ...getDefaultSystemVars() });
-}
-
-/**
- * Update variables to be injected and expand
- * environment variables to be expanded.
- *
- * @param {Mapping<string>} vars
- * @returns {Mapping<string>}
- */
-export function expandEnvVariables(vars: Mapping<string>): Mapping<string> {
-  const entries = Object.entries(vars);
-  const result = entries.reduce(
-    (acc, entry) => Object.assign({}, acc, { [entry[0]]: expandEnvVars(entry[1]) }) as Mapping<string>,
-    {} as Mapping<string>
-  );
-
-  return result;
+  return expandEnvVarsInMap({ ...vars, ...getDefaultSystemVars() });
 }
 
 /**

--- a/src/services/configInjection.ts
+++ b/src/services/configInjection.ts
@@ -57,7 +57,7 @@ export function convertToKeyValuePairs(vars: Mapping<string>): KeyValuePair[] {
 }
 
 /**
- * Setup the table in the database for config injection.
+ * Setup the table in the database with the injected config.
  *
  * @param {Connection} connection
  * @param {SyncConfig} config
@@ -82,4 +82,14 @@ export async function setupTable(connection: Connection, config: SyncConfig) {
     .getInstance()
     .insert(values)
     .into(injectedConfig.table);
+}
+
+/**
+ * Drop the injected config table.
+ *
+ * @param {Connection} connection
+ * @param {SyncConfig} config
+ */
+export async function dropTable(connection: Connection, config: SyncConfig) {
+  await connection.schema().dropTableIfExists(config.injectedConfig.table);
 }

--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -1,3 +1,5 @@
+import Mapping from '../domain/Mapping';
+
 const REGEX_VAR_EXPANSION = /\$\{([a-zA-Z]\w+)\}/g;
 
 /**
@@ -15,4 +17,21 @@ const REGEX_VAR_EXPANSION = /\$\{([a-zA-Z]\w+)\}/g;
  */
 export function expandEnvVars(value: string): string {
   return value.replace(REGEX_VAR_EXPANSION, (_, key) => process.env[key] || '');
+}
+
+/**
+ * Expand environment variables to be expanded that are
+ * found in the values of the given map (key => value pairs).
+ *
+ * @param {Mapping<string>} vars
+ * @returns {Mapping<string>}
+ */
+export function expandEnvVarsInMap(vars: Mapping<string>): Mapping<string> {
+  const entries = Object.entries(vars);
+  const result = entries.reduce(
+    (acc, entry) => Object.assign({}, acc, { [entry[0]]: expandEnvVars(entry[1]) }) as Mapping<string>,
+    {} as Mapping<string>
+  );
+
+  return result;
 }

--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -1,0 +1,18 @@
+const REGEX_VAR_EXPANSION = /\$\{([a-zA-Z]\w+)\}/g;
+
+/**
+ * Expands the environment variables present in the string.
+ * Returns the string as is, if no variables were present. And,
+ * in case the variable used in the string isn't defined it is
+ * substituted with an empty string ('').
+ *
+ *  Example:
+ *    Input: 'Current user is ${USER} at ${HOST}.'
+ *    Output: 'Current user is kabir at leapfrog.'
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function expandEnvVars(value: string): string {
+  return value.replace(REGEX_VAR_EXPANSION, (_, key) => process.env[key] || '');
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Check if the value is an object.
+ * TODO: Add tests.
+ *
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isObject(value: any): boolean {
+  if (value === null) {
+    return false;
+  }
+
+  return typeof value === 'function' || typeof value === 'object';
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -5,7 +5,7 @@
  * @param {*} value
  * @returns {boolean}
  */
-function isObject(value: any): boolean {
+export function isObject(value: any): boolean {
   if (value === null) {
     return false;
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -5,47 +5,19 @@ import { validate } from '../src/config';
 
 describe('config:', () => {
   describe('validate', () => {
-    it('throws error if injectedConfig.table is not found in the config.', () => {
-      expect(() =>
-        validate({
-          injectedConfig: {
-            table: ''
-          }
-        } as any)
-      ).to.throw('Invalid configuration value for `injectedConfig.table`.');
-
-      expect(() =>
-        validate({
-          injectedConfig: {
-            table: '      '
-          }
-        } as any)
-      ).to.throw('Invalid configuration value for `injectedConfig.table`.');
-    });
-
     it('throws error if injectedConfig.vars is not found or is invalid in the config.', () => {
-      expect(() =>
-        validate({
-          injectedConfig: {
-            table: 'test',
-            vars: 'foobar'
-          }
-        } as any)
-      ).to.throw('Invalid configuration value for `injectedConfig.vars`.');
+      expect(() => validate({ injectedConfig: { vars: 'foobar' } } as any)).to.throw(
+        'Invalid configuration value for `injectedConfig.vars`.'
+      );
 
-      expect(() =>
-        validate({
-          injectedConfig: {
-            table: 'test'
-          }
-        } as any)
-      ).to.throw('Invalid configuration value for `injectedConfig.vars`.');
+      expect(() => validate({ injectedConfig: {} } as any)).to.throw(
+        'Invalid configuration value for `injectedConfig.vars`.'
+      );
     });
 
     it('should return without error if the configuration is valid.', () => {
       validate({
         injectedConfig: {
-          table: '__injected_config',
           vars: {}
         }
       } as any);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,54 @@
+import 'mocha';
+import { expect } from 'chai';
+
+import { validate } from '../src/config';
+
+describe('config:', () => {
+  describe('validate', () => {
+    it('throws error if injectedConfig.table is not found in the config.', () => {
+      expect(() =>
+        validate({
+          injectedConfig: {
+            table: ''
+          }
+        } as any)
+      ).to.throw('Invalid configuration value for `injectedConfig.table`.');
+
+      expect(() =>
+        validate({
+          injectedConfig: {
+            table: '      '
+          }
+        } as any)
+      ).to.throw('Invalid configuration value for `injectedConfig.table`.');
+    });
+
+    it('throws error if injectedConfig.vars is not found or is invalid in the config.', () => {
+      expect(() =>
+        validate({
+          injectedConfig: {
+            table: 'test',
+            vars: 'foobar'
+          }
+        } as any)
+      ).to.throw('Invalid configuration value for `injectedConfig.vars`.');
+
+      expect(() =>
+        validate({
+          injectedConfig: {
+            table: 'test'
+          }
+        } as any)
+      ).to.throw('Invalid configuration value for `injectedConfig.vars`.');
+    });
+
+    it('should return without error if the configuration is valid.', () => {
+      validate({
+        injectedConfig: {
+          table: '__injected_config',
+          vars: {}
+        }
+      } as any);
+    });
+  });
+});

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -2,65 +2,9 @@ import 'mocha';
 import { expect } from 'chai';
 
 import { version as syncDbVersion } from '../package.json';
-import {
-  updateInjectedConfigVars,
-  prepareInjectionConfigVars,
-  convertToKeyValuePairs
-} from '../src/services/configInjection';
+import { prepareInjectionConfigVars, convertToKeyValuePairs } from '../src/services/configInjection';
 
 describe('Services: configInjection', () => {
-  describe('updateInjectedConfigVars', () => {
-    it('should return an empty object just-as-is', () => {
-      const vars = {};
-      const result = updateInjectedConfigVars(vars);
-
-      expect(result).to.deep.equal(vars);
-    });
-
-    it('should return a normal map of object just-as-is', () => {
-      const vars = {
-        var1: 'Foo',
-        var2: 'Bar',
-        var3: 'Baz'
-      };
-      const result = updateInjectedConfigVars(vars);
-
-      expect(result).to.deep.equal(vars);
-    });
-
-    it('should expand all the environment variables found in the values', () => {
-      process.env.TEST_ENV_VALUE1 = 'Test value 1';
-      process.env.TEST_ENV_VALUE2 = 'Test value 2';
-      process.env.TEST_FIRST_NAME = 'Kabir';
-      process.env.TEST_LAST_NAME = 'Baidhya';
-
-      const vars = {
-        var1: 'Foo',
-        var2: 'Bar',
-        var3: '${TEST_ENV_VALUE1}',
-        var4: '${TEST_ENV_VALUE2}',
-        var5: '${TEST_FIRST_NAME} ${TEST_LAST_NAME}',
-        var6: '${TEST_UNDEFINED_VALUE}'
-      };
-      const result = updateInjectedConfigVars(vars);
-
-      expect(result).to.deep.equal({
-        var1: 'Foo',
-        var2: 'Bar',
-        var3: 'Test value 1',
-        var4: 'Test value 2',
-        var5: 'Kabir Baidhya',
-        var6: ''
-      });
-
-      // Cleanup
-      process.env.TEST_ENV_VALUE1 = undefined;
-      process.env.TEST_ENV_VALUE2 = undefined;
-      process.env.TEST_FIRST_NAME = undefined;
-      process.env.TEST_LAST_NAME = undefined;
-    });
-  });
-
   describe('prepareInjectionConfigVars', () => {
     it('should return the default vars for injection even if empty object is given', async () => {
       const result = prepareInjectionConfigVars({});

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { expect } from 'chai';
 
-import { updateInjectedConfigVars } from '../src/services/configInjection';
+import { updateInjectedConfigVars, prepareInjectionConfigVars } from '../src/services/configInjection';
 
 describe('Services: configInjection', () => {
   describe('updateInjectedConfigVars', () => {
@@ -53,6 +53,36 @@ describe('Services: configInjection', () => {
       process.env.TEST_ENV_VALUE2 = undefined;
       process.env.TEST_FIRST_NAME = undefined;
       process.env.TEST_LAST_NAME = undefined;
+    });
+  });
+
+  describe('prepareInjectionConfigVars', async () => {
+    const { version: syncDbVersion } = await import('../package.json');
+
+    it('should return the default vars for injection even if empty object is given', async () => {
+      const result = prepareInjectionConfigVars({});
+
+      expect(result).to.deep.equal({
+        sync_db_version: syncDbVersion
+      });
+    });
+
+    it('should return both the added vars and the default vars for injection', async () => {
+      process.env.TEST_ENV_VALUE1 = 'Bar';
+
+      const result = prepareInjectionConfigVars({
+        var1: 'Foo',
+        var2: '${TEST_ENV_VALUE1}'
+      });
+
+      expect(result).to.deep.equal({
+        var1: 'Foo',
+        var2: 'Bar',
+        sync_db_version: syncDbVersion
+      });
+
+      // Cleanup
+      process.env.TEST_ENV_VALUE1 = undefined;
     });
   });
 });

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { expect } from 'chai';
 
-import { updateInjectedConfigVars, expandEnvVar } from '../src/services/configInjection';
+import { updateInjectedConfigVars } from '../src/services/configInjection';
 
 describe('Services: configInjection', () => {
   describe('updateInjectedConfigVars', () => {
@@ -12,48 +12,6 @@ describe('Services: configInjection', () => {
         var3: 'Baz'
       };
       expect(updateInjectedConfigVars(vars)).to.deep.equal(vars);
-    });
-  });
-
-  describe('expandEnvVar', () => {
-    afterEach(() => {
-      process.env.TEST1 = undefined;
-      process.env.TEST2 = undefined;
-    });
-
-    it('should return a regular string (w/o env variable) as-is.', () => {
-      expect(expandEnvVar('')).to.equal('');
-      expect(expandEnvVar('Hello World')).to.equal('Hello World');
-    });
-
-    it('should expand an environment variable value.', () => {
-      process.env.TEST1 = 'Foo bar';
-
-      const result = expandEnvVar('${TEST1}');
-
-      expect(result).to.equal('Foo bar');
-    });
-
-    it("should substitute an empty string in-place of the variable if the variable isn't defined.", () => {
-      expect(expandEnvVar('${TEST_UNDEFINED_VARIABLE}')).to.equal('');
-      expect(expandEnvVar('Substituted value = "${TEST_UNDEFINED_VARIABLE}"')).to.equal('Substituted value = ""');
-    });
-
-    it('should expand a string containing an environment variable.', () => {
-      process.env.TEST1 = 'Foo bar';
-
-      const result = expandEnvVar('Substituted value = "${TEST1}"');
-
-      expect(result).to.equal('Substituted value = "Foo bar"');
-    });
-
-    it('should expand a multiple environment variables.', () => {
-      process.env.TEST1 = 'Foo bar';
-      process.env.TEST2 = 'Bar foo';
-
-      const result = expandEnvVar('Substituted values are: "${TEST1}" and "${TEST2}"');
-
-      expect(result).to.equal('Substituted values are: "Foo bar" and "Bar foo"');
     });
   });
 });

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -11,23 +11,41 @@ describe('Services: configInjection', () => {
         var2: 'Bar',
         var3: 'Baz'
       };
-      expect(updateInjectedConfigVars(vars)).to.deep.equal(vars);
+      const result = updateInjectedConfigVars(vars);
+
+      expect(result).to.deep.equal(vars);
     });
 
     it('should expand all the environment variables found in the values', () => {
+      process.env.TEST_ENV_VALUE1 = 'Test value 1';
+      process.env.TEST_ENV_VALUE2 = 'Test value 2';
+      process.env.TEST_FIRST_NAME = 'Kabir';
+      process.env.TEST_LAST_NAME = 'Baidhya';
+
       const vars = {
         var1: 'Foo',
         var2: 'Bar',
         var3: '${TEST_ENV_VALUE1}',
-        var4: '${TEST_ENV_VALUE2}'
+        var4: '${TEST_ENV_VALUE2}',
+        var5: '${TEST_FIRST_NAME} ${TEST_LAST_NAME}',
+        var6: '${TEST_UNDEFINED_VALUE}'
       };
+      const result = updateInjectedConfigVars(vars);
 
-      expect(updateInjectedConfigVars(vars)).to.deep.equal({
+      expect(result).to.deep.equal({
         var1: 'Foo',
         var2: 'Bar',
         var3: 'Test value 1',
-        var4: 'Test value 2'
+        var4: 'Test value 2',
+        var5: 'Kabir Baidhya',
+        var6: ''
       });
+
+      // Cleanup
+      process.env.TEST_ENV_VALUE1 = undefined;
+      process.env.TEST_ENV_VALUE2 = undefined;
+      process.env.TEST_FIRST_NAME = undefined;
+      process.env.TEST_LAST_NAME = undefined;
     });
   });
 });

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -1,0 +1,17 @@
+import 'mocha';
+import { expect } from 'chai';
+
+import { updateInjectedConfigVars } from '../src/services/configInjection';
+
+describe('Services: configInjection', () => {
+  describe('updateInjectedConfigVars', () => {
+    it('should return a normal map of object just-as-is', () => {
+      const vars = {
+        var1: 'Foo',
+        var2: 'Bar',
+        var3: 'Baz'
+      };
+      expect(updateInjectedConfigVars(vars)).to.deep.equal(vars);
+    });
+  });
+});

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -5,6 +5,13 @@ import { updateInjectedConfigVars } from '../src/services/configInjection';
 
 describe('Services: configInjection', () => {
   describe('updateInjectedConfigVars', () => {
+    it('should return an empty object just-as-is', () => {
+      const vars = {};
+      const result = updateInjectedConfigVars(vars);
+
+      expect(result).to.deep.equal(vars);
+    });
+
     it('should return a normal map of object just-as-is', () => {
       const vars = {
         var1: 'Foo',

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -1,16 +1,21 @@
 import 'mocha';
 import { expect } from 'chai';
 
-import { version as syncDbVersion } from '../package.json';
-import { prepareInjectionConfigVars, convertToKeyValuePairs } from '../src/services/configInjection';
+import {
+  prepareInjectionConfigVars,
+  convertToKeyValuePairs,
+  getPackageMetadata
+} from '../src/services/configInjection';
 
 describe('Services: configInjection', () => {
+  const { version } = getPackageMetadata();
+
   describe('prepareInjectionConfigVars', () => {
     it('should return the default vars for injection even if empty object is given', async () => {
       const result = prepareInjectionConfigVars({});
 
       expect(result).to.deep.equal({
-        sync_db_version: syncDbVersion
+        sync_db_version: version
       });
     });
 
@@ -25,7 +30,7 @@ describe('Services: configInjection', () => {
       expect(result).to.deep.equal({
         var1: 'Foo',
         var2: 'Bar',
-        sync_db_version: syncDbVersion
+        sync_db_version: version
       });
 
       // Cleanup

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -13,5 +13,21 @@ describe('Services: configInjection', () => {
       };
       expect(updateInjectedConfigVars(vars)).to.deep.equal(vars);
     });
+
+    it('should expand all the environment variables found in the values', () => {
+      const vars = {
+        var1: 'Foo',
+        var2: 'Bar',
+        var3: '${TEST_ENV_VALUE1}',
+        var4: '${TEST_ENV_VALUE2}'
+      };
+
+      expect(updateInjectedConfigVars(vars)).to.deep.equal({
+        var1: 'Foo',
+        var2: 'Bar',
+        var3: 'Test value 1',
+        var4: 'Test value 2'
+      });
+    });
   });
 });

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -1,6 +1,7 @@
 import 'mocha';
 import { expect } from 'chai';
 
+import { version as syncDbVersion } from '../package.json';
 import { updateInjectedConfigVars, prepareInjectionConfigVars } from '../src/services/configInjection';
 
 describe('Services: configInjection', () => {
@@ -56,9 +57,7 @@ describe('Services: configInjection', () => {
     });
   });
 
-  describe('prepareInjectionConfigVars', async () => {
-    const { version: syncDbVersion } = await import('../package.json');
-
+  describe('prepareInjectionConfigVars', () => {
     it('should return the default vars for injection even if empty object is given', async () => {
       const result = prepareInjectionConfigVars({});
 

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -2,7 +2,11 @@ import 'mocha';
 import { expect } from 'chai';
 
 import { version as syncDbVersion } from '../package.json';
-import { updateInjectedConfigVars, prepareInjectionConfigVars } from '../src/services/configInjection';
+import {
+  updateInjectedConfigVars,
+  prepareInjectionConfigVars,
+  convertToKeyValuePairs
+} from '../src/services/configInjection';
 
 describe('Services: configInjection', () => {
   describe('updateInjectedConfigVars', () => {
@@ -82,6 +86,25 @@ describe('Services: configInjection', () => {
 
       // Cleanup
       process.env.TEST_ENV_VALUE1 = undefined;
+    });
+  });
+
+  describe('convertToKeyValuePairs', () => {
+    it('should convert an empty object into an empty array', () => {
+      expect(convertToKeyValuePairs({})).to.deep.equal([]);
+    });
+
+    it('should convert an object into an array of key / value pairs', () => {
+      const input = {
+        flag1: 'true',
+        flag2: 'false'
+      };
+      const expected = [
+        { key: 'flag1', value: 'true' },
+        { key: 'flag2', value: 'false' }
+      ];
+
+      expect(convertToKeyValuePairs(input)).to.deep.equal(expected);
     });
   });
 });

--- a/test/configInjection.test.ts
+++ b/test/configInjection.test.ts
@@ -1,22 +1,14 @@
 import 'mocha';
 import { expect } from 'chai';
 
-import {
-  prepareInjectionConfigVars,
-  convertToKeyValuePairs,
-  getPackageMetadata
-} from '../src/services/configInjection';
+import { prepareInjectionConfigVars, convertToKeyValuePairs } from '../src/services/configInjection';
 
 describe('Services: configInjection', () => {
-  const { version } = getPackageMetadata();
-
   describe('prepareInjectionConfigVars', () => {
     it('should return the default vars for injection even if empty object is given', async () => {
       const result = prepareInjectionConfigVars({});
 
-      expect(result).to.deep.equal({
-        sync_db_version: version
-      });
+      expect(result).to.deep.equal({});
     });
 
     it('should return both the added vars and the default vars for injection', async () => {
@@ -29,8 +21,7 @@ describe('Services: configInjection', () => {
 
       expect(result).to.deep.equal({
         var1: 'Foo',
-        var2: 'Bar',
-        sync_db_version: version
+        var2: 'Bar'
       });
 
       // Cleanup

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -23,7 +23,7 @@ describe('UTIL: env', () => {
       expect(result).to.equal('Foo bar');
     });
 
-    it("should substitute an empty string in-place of the variable if the variable isn't defined.", () => {
+    it('should substitute an empty string in-place of the variable if the variable isn\'t defined.', () => {
       expect(expandEnvVars('${TEST_UNDEFINED_VARIABLE}')).to.equal('');
       expect(expandEnvVars('Substituted value = "${TEST_UNDEFINED_VARIABLE}"')).to.equal('Substituted value = ""');
     });

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { expect } from 'chai';
 
-import { expandEnvVars } from '../src/util/env';
+import { expandEnvVars, expandEnvVarsInMap } from '../src/util/env';
 
 describe('UTIL: env', () => {
   describe('expandEnvVars', () => {
@@ -43,6 +43,58 @@ describe('UTIL: env', () => {
       const result = expandEnvVars('Substituted values are: "${TEST1}" and "${TEST2}"');
 
       expect(result).to.equal('Substituted values are: "Foo bar" and "Bar foo"');
+    });
+  });
+
+  describe('updateInjectedConfigVars', () => {
+    it('should return an empty object just-as-is', () => {
+      const vars = {};
+      const result = expandEnvVarsInMap(vars);
+
+      expect(result).to.deep.equal(vars);
+    });
+
+    it('should return a normal map of object just-as-is', () => {
+      const vars = {
+        var1: 'Foo',
+        var2: 'Bar',
+        var3: 'Baz'
+      };
+      const result = expandEnvVarsInMap(vars);
+
+      expect(result).to.deep.equal(vars);
+    });
+
+    it('should expand all the environment variables found in the values', () => {
+      process.env.TEST_ENV_VALUE1 = 'Test value 1';
+      process.env.TEST_ENV_VALUE2 = 'Test value 2';
+      process.env.TEST_FIRST_NAME = 'Kabir';
+      process.env.TEST_LAST_NAME = 'Baidhya';
+
+      const vars = {
+        var1: 'Foo',
+        var2: 'Bar',
+        var3: '${TEST_ENV_VALUE1}',
+        var4: '${TEST_ENV_VALUE2}',
+        var5: '${TEST_FIRST_NAME} ${TEST_LAST_NAME}',
+        var6: '${TEST_UNDEFINED_VALUE}'
+      };
+      const result = expandEnvVarsInMap(vars);
+
+      expect(result).to.deep.equal({
+        var1: 'Foo',
+        var2: 'Bar',
+        var3: 'Test value 1',
+        var4: 'Test value 2',
+        var5: 'Kabir Baidhya',
+        var6: ''
+      });
+
+      // Cleanup
+      process.env.TEST_ENV_VALUE1 = undefined;
+      process.env.TEST_ENV_VALUE2 = undefined;
+      process.env.TEST_FIRST_NAME = undefined;
+      process.env.TEST_LAST_NAME = undefined;
     });
   });
 });

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,48 @@
+import 'mocha';
+import { expect } from 'chai';
+
+import { expandEnvVars } from '../src/util/env';
+
+describe('UTIL: env', () => {
+  describe('expandEnvVars', () => {
+    afterEach(() => {
+      process.env.TEST1 = undefined;
+      process.env.TEST2 = undefined;
+    });
+
+    it('should return a regular string (w/o env variable) as-is.', () => {
+      expect(expandEnvVars('')).to.equal('');
+      expect(expandEnvVars('Hello World')).to.equal('Hello World');
+    });
+
+    it('should expand an environment variable value.', () => {
+      process.env.TEST1 = 'Foo bar';
+
+      const result = expandEnvVars('${TEST1}');
+
+      expect(result).to.equal('Foo bar');
+    });
+
+    it("should substitute an empty string in-place of the variable if the variable isn't defined.", () => {
+      expect(expandEnvVars('${TEST_UNDEFINED_VARIABLE}')).to.equal('');
+      expect(expandEnvVars('Substituted value = "${TEST_UNDEFINED_VARIABLE}"')).to.equal('Substituted value = ""');
+    });
+
+    it('should expand a string containing an environment variable.', () => {
+      process.env.TEST1 = 'Foo bar';
+
+      const result = expandEnvVars('Substituted value = "${TEST1}"');
+
+      expect(result).to.equal('Substituted value = "Foo bar"');
+    });
+
+    it('should expand a multiple environment variables.', () => {
+      process.env.TEST1 = 'Foo bar';
+      process.env.TEST2 = 'Bar foo';
+
+      const result = expandEnvVars('Substituted values are: "${TEST1}" and "${TEST2}"');
+
+      expect(result).to.equal('Substituted values are: "Foo bar" and "Bar foo"');
+    });
+  });
+});

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,27 @@
+import 'mocha';
+import { expect } from 'chai';
+
+import { isObject } from '../src/util/types';
+
+describe('UTIL: types', () => {
+  describe('isObject', () => {
+    it('should return true if it is an object.', () => {
+      expect(isObject({ foo: 'bar' })).to.equal(true);
+      expect(isObject({})).to.equal(true);
+      expect(isObject(Object())).to.equal(true);
+      expect(isObject(() => 'test')).to.equal(true);
+      expect(isObject(['foo', 'bar'])).to.equal(true);
+    });
+
+    it('should return false for a scalar value.', () => {
+      expect(isObject(5)).to.equal(false);
+      expect(isObject(-5)).to.equal(false);
+      expect(isObject(1.098)).to.equal(false);
+      expect(isObject('foo')).to.equal(false);
+      expect(isObject(true)).to.equal(false);
+      expect(isObject(false)).to.equal(false);
+      expect(isObject(null)).to.equal(false);
+      expect(isObject(undefined)).to.equal(false);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "noUnusedLocals": true,
     "strict": true,
     "target": "es2017",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "importHelpers": true,
     "module": "commonjs",
     "outDir": "lib",
-    "rootDir": "src",
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,12 @@
     "importHelpers": true,
     "module": "commonjs",
     "outDir": "lib",
+    "rootDir": "src",
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "strict": true,
     "target": "es2017",
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Introduce config injection into SQL scripts
- Ability to inject dynamic configurations into the scripts such that the scripts being run via sync-db can access them during the execution. 
- The lifetime of these configurations is limited to only when sync-db is running. And only the scripts directly triggered by `sync-db` can access them. Once they've finished running, the configurations are cleaned up.
- Tested and updated the sample project here :point_right:  https://github.com/leapfrogtechnology/sync-db/pull/37

### How it works?

Add configurations to be injected in the `sync-db.yml` file. It supports environment variable expansion too, so any confidential values / secrets could come through env vars as well.
```yml
hooks:
  post_sync:
    - scripts/setup.sql
injectedConfig:
  vars:
    create_admin: ${CREATE_ADMIN}
    admin_email: 'admin@example.com'
    task_status: ${TASK_STATUS}
```

Now, when `sync-db` is run it creates a temporary table named `__injected_config` which will contain these injected configurations. 

The table would look like this in the run-time. 

| key | value |
|------|---------|
| create_admin | true |
| admin_email | admin@example.com |
| task_status | somevalue |

Now, when the scripts like this runs through `sync-db`, it can access the values in the run-time.

```sql
-- File: ./scripts/setup.sql

--
-- Setup data.
--
DECLARE @create_admin BIT;
DECLARE @admin_email VARCHAR(100);
DECLARE @task_status VARCHAR(100);

SET @create_admin = (SELECT IIF([value] = 'true', 1, 0) FROM __injected_config WHERE [key] = 'create_admin');
SET @admin_email = (SELECT [value] FROM __injected_config WHERE [key] = 'admin_email');
SET @task_status = (SELECT [value] FROM __injected_config WHERE [key] = 'task_status');

-- Setup data.
EXEC testdata.setup_data @create_admin, @admin_email, @task_status;
```

**Note: This table is temporary. Once all the scripts in the transaction have finished running, it will be dropped automatically.** 

