### PR TITLE
Generate connection with port as number when using --generate-connections CLI arg

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -80,7 +80,7 @@ export function resolveConnectionsFromEnv(): ConnectionConfig[] {
   const connection = {
     client: process.env.DB_CLIENT,
     host: process.env.DB_HOST,
-    port: process.env.DB_PORT,
+    port: +process.env.DB_PORT,
     user: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,7 +80,7 @@ export function resolveConnectionsFromEnv(): ConnectionConfig[] {
   const connection = {
     client: process.env.DB_CLIENT,
     host: process.env.DB_HOST,
-    port: +process.env.DB_PORT,
+    port: +(process.env.DB_PORT || 1433),
     user: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,


### PR DESCRIPTION
# Issue
The `connections.sync-db.json` generated using `--generate-connections` creates the connection with `port` as `string` while `sync-db` expect a `number`.
```bash
$ sync-db --generate-connections
```
Else it fails with the error:
`Error: An error occurred: TypeError: The "config.options.port" property must be of type number.`
For example,
Following `env` produces the connections below:
**`env`**
```
DB_CLIENT=mssql
DB_HOST=localhost
DB_PORT=1433
DB_USERNAME=user
DB_PASSWORD=Password@123
DB_NAME=db1
DB_ENCRYPTION=true
```
**Actual `connections.sync-db.json`**
```json
{
  "connections": [
    {
      "client": "mssql",
      "host": "localhost",
      "port": "1433",
      "user": "user",
      "password": "Password@123",
      "database": "db1",
      "options": {
        "encrypt": "true"
      }
    }
  ]
}
```
**Expected `connections.sync-db.json`**
```json
{
  "connections": [
    {
      "client": "mssql",
      "host": "localhost",
      "port": 1433,
      "user": "user",
      "password": "Password@123",
      "database": "db1",
      "options": {
        "encrypt": "true"
      }
    }
  ]
}
```

# Fix
- Cast `DB_PORT` to `number` when generating connection from `env`