### PR TITLE
Avoid vendor specific defaults in the config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -80,7 +80,7 @@ export function resolveConnectionsFromEnv(): ConnectionConfig[] {
   const connection = {
     client: process.env.DB_CLIENT,
     host: process.env.DB_HOST,
-    port: +(process.env.DB_PORT),
+    port: process.env.DB_PORT ? +(process.env.DB_PORT) : null,
     user: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,7 +80,7 @@ export function resolveConnectionsFromEnv(): ConnectionConfig[] {
   const connection = {
     client: process.env.DB_CLIENT,
     host: process.env.DB_HOST,
-    port: +(process.env.DB_PORT || 1433),
+    port: +(process.env.DB_PORT),
     user: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,


### PR DESCRIPTION
Port number 1433 is for mssql only; sync-db is vendor agnostic - at least it supports mssql and pg at the moment.