### PR TITLE
Add new io utility for standard I/O operations

### DIFF
--- a/src/util/io.ts
+++ b/src/util/io.ts
@@ -2,18 +2,20 @@
  * Prints a line into the console (stdout).
  *
  * @param {string} [message='']
+ * @returns {Promise<any>}
  */
-export function printLine(message: string = '') {
-  print(message.toString() + '\n');
+export function printLine(message: string = ''): Promise<any> {
+  return print(message.toString() + '\n');
 }
 
 /**
  * Prints a message into the console (stdout).
  *
  * @param {string} message
+ * @returns {Promise<any>}
  */
-export function print(message: string) {
-  process.stdout.write(message.toString());
+export function print(message: string): Promise<any> {
+  return new Promise(resolve => process.stdout.write(message.toString(), resolve));
 }
 
 /**
@@ -21,7 +23,8 @@ export function print(message: string) {
  * into the stderr.
  *
  * @param {Error} error
+ * @returns {Promise<any>}
  */
-export function printError(error: Error) {
-  process.stderr.write((error.stack || error).toString() + '\n');
+export function printError(error: Error): Promise<any> {
+  return new Promise(resolve => process.stderr.write((error.stack || error).toString() + '\n', resolve));
 }

--- a/src/util/io.ts
+++ b/src/util/io.ts
@@ -1,0 +1,27 @@
+/**
+ * Prints a line into the console (stdout).
+ *
+ * @param {string} [message='']
+ */
+export function printLine(message: string = '') {
+  print(message.toString() + '\n');
+}
+
+/**
+ * Prints a message into the console (stdout).
+ *
+ * @param {string} message
+ */
+export function print(message: string) {
+  process.stdout.write(message.toString());
+}
+
+/**
+ * Prints an error message with stack trace available
+ * into the stderr.
+ *
+ * @param {Error} error
+ */
+export function printError(error: Error) {
+  process.stderr.write((error.stack || error).toString() + '\n');
+}


### PR DESCRIPTION
- Add `io` utility to support standard IO operations like writing to `stdout` and `stderr`. This is a CLI application so all the outputs should go through these utilities to the stdout or stderr if error. 
- Logs are separate than this - logs are sent only when `DEBUG=` is provided, they are meant to go in the log service instead.
- The CLI output is for the user.

### Why Asynchronous?
Streams in node will get unpredictable if we don't force between either a synchronous or asynchronous behavior. 

To be fully deterministic - they should be either 100% async or 100% sync - I chose async just to make things consistent with general IO.

![image](https://user-images.githubusercontent.com/3315763/75004747-40f65580-5494-11ea-9436-253db12d4cee.png)



