### PR TITLE
Support resolving connections from the environment directly as a fallback option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ import DbConfig from './domain/DbConfig';
 import SyncConfig from './domain/SyncConfig';
 import ConnectionConfig from './domain/ConnectionConfig';
 import { prepareInjectionConfigVars } from './services/configInjection';
-import { DEFAULT_CONFIG, CONFIG_FILENAME, CONNECTIONS_FILENAME, ENV_KEYS } from './constants';
+import { DEFAULT_CONFIG, CONFIG_FILENAME, CONNECTIONS_FILENAME, REQUIRED_ENV_KEYS } from './constants';
 
 /**
  * Load config yaml file.
@@ -117,7 +117,7 @@ function validateConnections(keys: string[]): void {
 export function resolveConnectionsFromEnv(): ConnectionConfig[] {
   log('Resolving connections from the environment variables.');
 
-  validateConnections(ENV_KEYS);
+  validateConnections(REQUIRED_ENV_KEYS);
 
   const connection = {
     client: process.env.DB_CLIENT,

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,16 +64,15 @@ export async function resolveConnections(): Promise<ConnectionConfig[]> {
 
   const filename = path.resolve(process.cwd(), CONNECTIONS_FILENAME);
   const connectionsFileExists = await fs.exists(filename);
+
   let connections;
 
   // If connections file exists, resolve connections from that.
   // otherwise fallback to getting the connection from the env vars.
   if (connectionsFileExists) {
-    log('Resolving file: %s', filename);
-
     connections = await resolveConnectionsFromFile(filename);
   } else {
-    log('Connections file does not exist. Falling back to environment variables.');
+    log('Connections file not provided.');
 
     connections = resolveConnectionsFromEnv();
   }
@@ -116,6 +115,8 @@ function validateConnections(keys: string[]): void {
  * @returns {ConnectionConfig[]}
  */
 export function resolveConnectionsFromEnv(): ConnectionConfig[] {
+  log('Getting connections from the environment.');
+
   validateConnections(ENV_KEYS);
 
   const connection = {
@@ -140,6 +141,8 @@ export function resolveConnectionsFromEnv(): ConnectionConfig[] {
  * @returns {Promise<ConnectionConfig[]>}
  */
 async function resolveConnectionsFromFile(filename: string): Promise<ConnectionConfig[]> {
+  log('Resolving file: %s', filename);
+
   const loaded = await fs.read(filename);
   const { connections } = JSON.parse(loaded) as DbConfig;
   // TODO: Validate the connections received from file.

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,7 +115,7 @@ function validateConnections(keys: string[]): void {
  * @returns {ConnectionConfig[]}
  */
 export function resolveConnectionsFromEnv(): ConnectionConfig[] {
-  log('Getting connections from the environment.');
+  log('Resolving connections from the environment variables.');
 
   validateConnections(ENV_KEYS);
 
@@ -146,6 +146,7 @@ async function resolveConnectionsFromFile(filename: string): Promise<ConnectionC
 
   const loaded = await fs.read(filename);
   const { connections } = JSON.parse(loaded) as DbConfig;
+
   // TODO: Validate the connections received from file.
 
   return connections;

--- a/src/config.ts
+++ b/src/config.ts
@@ -121,6 +121,7 @@ export function resolveConnectionsFromEnv(): ConnectionConfig[] {
 
   const connection = {
     client: process.env.DB_CLIENT,
+    id: process.env.DB_ID,
     host: process.env.DB_HOST,
     port: process.env.DB_PORT ? +process.env.DB_PORT : null,
     user: process.env.DB_USERNAME,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,4 +32,4 @@ export const DEFAULT_SYNC_PARAMS: SyncParams = {
   onFailed: (context: ExecutionContext) => Promise.resolve()
 };
 
-export const ENV_KEYS = ['DB_HOST', 'DB_PASSWORD', 'DB_NAME', 'DB_USERNAME', 'DB_PORT', 'DB_CLIENT', 'DB_ENCRYPTION'];
+export const REQUIRED_ENV_KEYS = ['DB_HOST', 'DB_PASSWORD', 'DB_NAME', 'DB_USERNAME', 'DB_PORT', 'DB_CLIENT'];

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -39,6 +39,12 @@ describe('config:', () => {
       process.env.DB_PASSWORD = '';
       process.env.DB_NAME = '';
     });
+
+    it('should throw an error if the required env vars are not provided.', () => {
+      expect(() => resolveConnectionsFromEnv()).to.throw(
+        'Following environment variables were not set: DB_HOST, DB_PASSWORD, DB_NAME, DB_USERNAME, DB_PORT, DB_CLIENT'
+      );
+    });
   });
 
   describe('validate', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,10 +1,46 @@
 import { expect } from 'chai';
 import { it, describe } from 'mocha';
 
-import { validate, getConnectionId } from '../src/config';
 import ConnectionConfig from '../src/domain/ConnectionConfig';
+import { validate, getConnectionId, resolveConnectionsFromEnv } from '../src/config';
 
 describe('config:', () => {
+  describe('resolveConnectionsFromEnv', () => {
+    it('should return the connection using the env vars.', () => {
+      process.env.DB_CLIENT = 'mssql';
+      process.env.DB_ID = 'mydb';
+      process.env.DB_HOST = 'localhost';
+      process.env.DB_PORT = '1234';
+      process.env.DB_USERNAME = 'user';
+      process.env.DB_PASSWORD = 'password';
+      process.env.DB_NAME = 'database';
+
+      const connections = resolveConnectionsFromEnv();
+
+      expect(connections[0]).to.deep.equal({
+        client: 'mssql',
+        id: 'mydb',
+        host: 'localhost',
+        port: 1234,
+        user: 'user',
+        password: 'password',
+        database: 'database',
+        options: {
+          encrypt: false
+        }
+      });
+
+      // Cleanup
+      process.env.DB_CLIENT = '';
+      process.env.DB_ID = '';
+      process.env.DB_HOST = '';
+      process.env.DB_PORT = '';
+      process.env.DB_USERNAME = '';
+      process.env.DB_PASSWORD = '';
+      process.env.DB_NAME = '';
+    });
+  });
+
   describe('validate', () => {
     it('throws error if injectedConfig.vars is not found or is invalid in the config.', () => {
       expect(() => validate({ injectedConfig: { vars: 'foobar' } } as any)).to.throw(


### PR DESCRIPTION
- Support resolving the connections from the environment variables if `connections.sync-db.json` does not exist.
- User don't always have to provide `connections.sync-db.json` now unless they want to or they have multiple connections.
- When this fallback option is chosen, if the environment variables required are not found an error is thrown just like what `--generate-connections` would have thrown.
- Add an ability to set connection `id` with environment variable `DB_ID`.

No need a workaround like these now when you want the connections to be generated:
```bash
$ sync-db --generate-connections && sync-db
```
Just this would do the same if you have your environment set
```bash
$ sync-db
```