### PR TITLE
Drop Node 8.x support - minimum required version >= 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - node
   - 10
-  - 8
 
 before_script:
   - yarn format:check

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^3.8.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">= 10.16.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**BREAKING CHANGE**

- Drop node 8 support and require node 10.x as the minimum required version.

