### PR TITLE
Upgrade prettier and reformat code

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,7 @@
   "tabWidth": 2,
   "useTabs": false,
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
 }

--- a/examples/node-app-mssql/.eslintrc
+++ b/examples/node-app-mssql/.eslintrc
@@ -3,9 +3,7 @@
     "node": true,
     "es6": true
   },
-  "extends": [
-    "eslint-config-leapfrog"
-  ],
+  "extends": ["eslint-config-leapfrog"],
   "parserOptions": {
     "ecmaVersion": 2017,
     "sourceType": "module"

--- a/examples/node-app-mssql/docker-compose.yml
+++ b/examples/node-app-mssql/docker-compose.yml
@@ -1,17 +1,17 @@
-version: "3.3"
+version: '3.3'
 
-services: 
+services:
   mssql:
-    container_name: "example-mssql"
-    image: "mcr.microsoft.com/mssql/server:2017-GA-ubuntu"
-    ports: 
-      - "1433:1433"
-    environment: 
-      ACCEPT_EULA: "Y"
+    container_name: 'example-mssql'
+    image: 'mcr.microsoft.com/mssql/server:2017-GA-ubuntu'
+    ports:
+      - '1433:1433'
+    environment:
+      ACCEPT_EULA: 'Y'
       SA_PASSWORD: ${DB_PASSWORD}
 
   app:
-    container_name: "example-app"
+    container_name: 'example-app'
     environment:
       DEBUG: 'sync-db*'
     build: .

--- a/examples/node-app-mssql/src/migrations/20191124213800_create_tasks_table.js
+++ b/examples/node-app-mssql/src/migrations/20191124213800_create_tasks_table.js
@@ -9,14 +9,8 @@ export function up(knex) {
     table.increments();
     table.string('title').notNullable();
     table.string('description').notNullable();
-    table
-      .boolean('is_complete')
-      .notNullable()
-      .defaultTo(false);
-    table
-      .integer('user_id')
-      .references('id')
-      .inTable('users');
+    table.boolean('is_complete').notNullable().defaultTo(false);
+    table.integer('user_id').references('id').inTable('users');
     table.timestamp('created_at').defaultTo(knex.fn.now());
     table.timestamp('updated_at').defaultTo(knex.fn.now());
   });

--- a/examples/node-app-pg/docker-compose.yml
+++ b/examples/node-app-pg/docker-compose.yml
@@ -1,13 +1,13 @@
-version: "3.3"
+version: '3.3'
 services:
   db:
-    image: "postgres"
-    container_name: "example-pg"
+    image: 'postgres'
+    container_name: 'example-pg'
     ports:
-      - "5432:5432"
+      - '5432:5432'
     environment:
       DATABASE_URL: ${DATABASE_URL}
-      POSTGRES_DB: "mydatabasename"
+      POSTGRES_DB: 'mydatabasename'
   app:
-    container_name: "example-app"
+    container_name: 'example-app'
     build: .

--- a/examples/node-app-pg/src/migrations/20191202053206_todos.js
+++ b/examples/node-app-pg/src/migrations/20191202053206_todos.js
@@ -9,10 +9,7 @@ exports.up = knex => {
     table.increments('id');
     table.string('name').notNullable();
     table.enu('status', ['active', 'inactive']).notNullable();
-    table
-      .foreign('user')
-      .references('id')
-      .inTable('users');
+    table.foreign('user').references('id').inTable('users');
     table.timestamp('created_at').defaultTo(knex.fn.now());
     table.timestamp('updated_at').defaultTo(knex.fn.now());
   });

--- a/examples/node-mssql-programmatic-use/.eslintrc
+++ b/examples/node-mssql-programmatic-use/.eslintrc
@@ -3,9 +3,7 @@
     "node": true,
     "es6": true
   },
-  "extends": [
-    "eslint-config-leapfrog"
-  ],
+  "extends": ["eslint-config-leapfrog"],
   "parserOptions": {
     "ecmaVersion": 2017,
     "sourceType": "module"

--- a/examples/node-mssql-programmatic-use/docker-compose.yml
+++ b/examples/node-mssql-programmatic-use/docker-compose.yml
@@ -1,15 +1,15 @@
-version: "3.3"
+version: '3.3'
 
-services: 
+services:
   mssql:
-    container_name: "example-mssql"
-    image: "mcr.microsoft.com/mssql/server:2017-GA-ubuntu"
-    ports: 
-      - "1433:1433"
-    environment: 
-      ACCEPT_EULA: "Y"
+    container_name: 'example-mssql'
+    image: 'mcr.microsoft.com/mssql/server:2017-GA-ubuntu'
+    ports:
+      - '1433:1433'
+    environment:
+      ACCEPT_EULA: 'Y'
       SA_PASSWORD: ${DB_PASSWORD}
-  
+
   app:
-    container_name: "example-app"
+    container_name: 'example-app'
     build: .

--- a/examples/node-mssql-programmatic-use/src/migrations/20191124213800_create_task_table.js
+++ b/examples/node-mssql-programmatic-use/src/migrations/20191124213800_create_task_table.js
@@ -9,14 +9,8 @@ export function up(knex) {
     table.increments();
     table.string('title').notNullable();
     table.string('description').notNullable();
-    table
-      .boolean('is_complete')
-      .notNullable()
-      .defaultTo(false);
-    table
-      .integer('user_id')
-      .references('id')
-      .inTable('users');
+    table.boolean('is_complete').notNullable().defaultTo(false);
+    table.integer('user_id').references('id').inTable('users');
     table.timestamp('created_at').defaultTo(knex.fn.now());
     table.timestamp('updated_at').defaultTo(knex.fn.now());
   });

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "codecov": "^3.5.0",
     "mocha": "^5",
     "nyc": "^14.1.1",
-    "prettier": "1.19.1",
+    "prettier": "2.0.2",
     "ts-node": "^8",
     "tslint": "^6.0.0",
     "tslint-config-leapfrog": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,10 +1851,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-prettier@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- Upgrade prettier to the latest version.
- Reconfigure few prettier due to new defaults
- Reformat whole codebase.

**Note:** Merge https://github.com/leapfrogtechnology/sync-db/pull/60 first. Requires node >= 10.