### PR TITLE
Ability to run all commands for a specific connection using a CLI option (--only)

### DIFF
--- a/src/commands/migrate-latest.ts
+++ b/src/commands/migrate-latest.ts
@@ -1,5 +1,5 @@
-import { Command } from '@oclif/command';
 import { bold, red, cyan } from 'chalk';
+import { Command, flags } from '@oclif/command';
 
 import { migrateLatest } from '../api';
 import { dbLogger } from '../util/logger';
@@ -9,6 +9,13 @@ import OperationResult from '../domain/operation/OperationResult';
 
 class MigrateLatest extends Command {
   static description = 'Run the migrations up to the latest changes.';
+
+  static flags = {
+    only: flags.string({
+      helpValue: 'CONNECTION_ID',
+      description: 'Filter only a single connection.'
+    })
+  };
 
   /**
    * Success handler.
@@ -51,10 +58,12 @@ class MigrateLatest extends Command {
    * @returns {Promise<void>}
    */
   async run(): Promise<void> {
+    const { flags: parsedFlags } = this.parse(MigrateLatest);
     const config = await loadConfig();
     const connections = await resolveConnections();
 
     const results = await migrateLatest(config, connections, {
+      ...parsedFlags,
       onSuccess: this.onSuccess,
       onFailed: this.onFailed
     });

--- a/src/commands/migrate-list.ts
+++ b/src/commands/migrate-list.ts
@@ -1,4 +1,4 @@
-import { Command } from '@oclif/command';
+import { Command, flags } from '@oclif/command';
 import { bold, grey, red, cyan, yellow } from 'chalk';
 
 import { migrateList } from '../api';
@@ -8,6 +8,13 @@ import OperationResult from '../domain/operation/OperationResult';
 
 class MigrateList extends Command {
   static description = 'List all the migrations.';
+
+  static flags = {
+    only: flags.string({
+      helpValue: 'CONNECTION_ID',
+      description: 'Filter only a single connection.'
+    })
+  };
 
   /**
    * Success handler.
@@ -55,10 +62,12 @@ class MigrateList extends Command {
    * @returns {Promise<void>}
    */
   async run(): Promise<void> {
+    const { flags: parsedFlags } = this.parse(MigrateList);
     const config = await loadConfig();
     const connections = await resolveConnections();
 
     const results = await migrateList(config, connections, {
+      ...parsedFlags,
       onSuccess: this.onSuccess,
       onFailed: this.onFailed
     });

--- a/src/commands/migrate-rollback.ts
+++ b/src/commands/migrate-rollback.ts
@@ -1,5 +1,5 @@
-import { Command } from '@oclif/command';
 import { bold, red, cyan } from 'chalk';
+import { Command, flags } from '@oclif/command';
 
 import { migrateRollback } from '../api';
 import { dbLogger } from '../util/logger';
@@ -9,6 +9,13 @@ import OperationResult from '../domain/operation/OperationResult';
 
 class MigrateRollback extends Command {
   static description = 'Rollback migrations up to the last run batch.';
+
+  static flags = {
+    only: flags.string({
+      helpValue: 'CONNECTION_ID',
+      description: 'Filter only a single connection.'
+    })
+  };
 
   /**
    * Success handler.
@@ -51,10 +58,12 @@ class MigrateRollback extends Command {
    * @returns {Promise<void>}
    */
   async run(): Promise<void> {
+    const { flags: parsedFlags } = this.parse(MigrateRollback);
     const config = await loadConfig();
     const connections = await resolveConnections();
 
     const results = await migrateRollback(config, connections, {
+      ...parsedFlags,
       onSuccess: this.onSuccess,
       onFailed: this.onFailed
     });

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -1,5 +1,5 @@
 import { bold, red } from 'chalk';
-import { Command } from '@oclif/command';
+import { Command, flags } from '@oclif/command';
 
 import { prune } from '../api';
 import { printLine, printError } from '../util/io';
@@ -8,6 +8,13 @@ import OperationResult from '../domain/operation/OperationResult';
 
 class Prune extends Command {
   static description = 'Drop all the synchronized db objects except the ones created via migrations.';
+
+  static flags = {
+    only: flags.string({
+      helpValue: 'CONNECTION_ID',
+      description: 'Filter only a single connection.'
+    })
+  };
 
   /**
    * Success handler.
@@ -31,10 +38,12 @@ class Prune extends Command {
    * @returns {Promise<void>}
    */
   async run(): Promise<void> {
+    const { flags: parsedFlags } = this.parse(Prune);
     const config = await loadConfig();
     const connections = await resolveConnections();
 
     const results = await prune(config, connections, {
+      ...parsedFlags,
       onSuccess: this.onSuccess,
       onFailed: this.onFailed
     });

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -18,7 +18,11 @@ class Synchronize extends Command {
     version: flags.version({ char: 'v', description: 'Print version', name: 'sync-db' }),
     help: flags.help({ char: 'h', description: 'Print help information' }),
     force: flags.boolean({ char: 'f', description: 'Force synchronization' }),
-    'skip-migration': flags.boolean({ description: 'Skip running migrations' })
+    'skip-migration': flags.boolean({ description: 'Skip running migrations' }),
+    only: flags.string({
+      helpValue: 'CONNECTION_ID',
+      description: 'Run synchronize only on a single connection.'
+    })
   };
 
   /**

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -9,19 +9,17 @@ import { printError, printLine, printInfo } from '../util/io';
 import OperationResult from '../domain/operation/OperationResult';
 
 class Synchronize extends Command {
-  static description = 'Synchronize database';
+  static description = 'Synchronize all the configured database connections.';
 
   /**
    * Available CLI flags.
    */
   static flags = {
-    version: flags.version({ char: 'v', description: 'Print version', name: 'sync-db' }),
-    help: flags.help({ char: 'h', description: 'Print help information' }),
     force: flags.boolean({ char: 'f', description: 'Force synchronization' }),
     'skip-migration': flags.boolean({ description: 'Skip running migrations' }),
     only: flags.string({
       helpValue: 'CONNECTION_ID',
-      description: 'Run synchronize only on a single connection.'
+      description: 'Filter only a single connection.'
     })
   };
 

--- a/src/domain/operation/OperationParams.ts
+++ b/src/domain/operation/OperationParams.ts
@@ -1,6 +1,7 @@
 import OperationResult from './OperationResult';
 
 interface OperationParams<T = any> {
+  only?: string;
   onSuccess?: (result: OperationResult<T>) => Promise<any>;
   onFailed?: (result: OperationResult<T>) => Promise<any>;
 }

--- a/src/util/list.ts
+++ b/src/util/list.ts
@@ -6,12 +6,13 @@
  * @param {any[]} list
  * @param {(element: any, index: number) => boolean} filter
  * @param {(element: any, index: number) => T} [map]
+ * @returns {T[]}
  */
 export function fmap<T>(
   list: any[],
   filter: (element: any, index: number) => boolean,
   map?: (element: any, index: number) => T
-) {
+): T[] {
   if (!Array.isArray(list)) {
     throw new Error('The first argument must be an array.');
   }

--- a/src/util/list.ts
+++ b/src/util/list.ts
@@ -4,20 +4,20 @@
  * Note: Saves an additional loop while doing filter & map separately.
  *
  * @param {any[]} list
- * @param {(element: any, index: number) => boolean} filter
+ * @param {(((element: any, index: number) => boolean) | false)} filter
  * @param {(element: any, index: number) => T} [map]
  * @returns {T[]}
  */
 export function fmap<T>(
   list: any[],
-  filter: (element: any, index: number) => boolean,
+  filter: ((element: any, index: number) => boolean) | false,
   map?: (element: any, index: number) => T
 ): T[] {
   if (!Array.isArray(list)) {
     throw new Error('The first argument must be an array.');
   }
 
-  if (typeof filter !== 'function') {
+  if (filter && typeof filter !== 'function') {
     throw new Error('Second argument must be a filter function.');
   }
 
@@ -27,12 +27,14 @@ export function fmap<T>(
 
   const result = [];
 
-  for (const [index, value] of list.entries()) {
-    if (!filter(value, index)) {
+  for (let index = 0; index < list.length; index++) {
+    // If no filter function supplied - apply no filter.
+    // If provided the condition must hold truthy to include it.
+    if (filter && !filter(list[index], index)) {
       continue;
     }
 
-    result.push(map ? map(value, index) : value);
+    result.push(map ? map(list[index], index) : list[index]);
   }
 
   return result;

--- a/src/util/list.ts
+++ b/src/util/list.ts
@@ -1,0 +1,38 @@
+/**
+ * Applies a filter and map functions into an array to return a new array.
+ *
+ * Note: Saves an additional loop while doing filter & map separately.
+ *
+ * @param {any[]} list
+ * @param {(element: any, index: number) => boolean} filter
+ * @param {(element: any, index: number) => T} [map]
+ */
+export function fmap<T>(
+  list: any[],
+  filter: (element: any, index: number) => boolean,
+  map?: (element: any, index: number) => T
+) {
+  if (!Array.isArray(list)) {
+    throw new Error('The first argument must be an array.');
+  }
+
+  if (typeof filter !== 'function') {
+    throw new Error('Second argument must be a filter function.');
+  }
+
+  if (map && typeof map !== 'function') {
+    throw new Error('Third argument must be a map function.');
+  }
+
+  const result = [];
+
+  for (const [index, value] of list.entries()) {
+    if (!filter(value, index)) {
+      continue;
+    }
+
+    result.push(map ? map(value, index) : value);
+  }
+
+  return result;
+}

--- a/test/commands/synchronize.test.ts
+++ b/test/commands/synchronize.test.ts
@@ -11,7 +11,7 @@ describe('CLI: synchronize', () => {
     it('should print help message.', async () => {
       const { stdout } = await runCli(['synchronize', '--help'], { cwd });
 
-      expect(stdout).contains('Synchronize database');
+      expect(stdout).contains('Synchronize');
       expect(stdout).contains(`USAGE\n  $ sync-db synchronize`);
     });
   });

--- a/test/util/list.test.ts
+++ b/test/util/list.test.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { fmap } from '../../src/util/list';
+
+describe('UTIL: list', () => {
+  describe('fmap', () => {
+    it('should apply filter and map to the list into a new array.', () => {
+      const list = [1, 2, 3, 4];
+
+      expect(
+        fmap(
+          list,
+          x => x % 2 === 0,
+          x => x + 2
+        )
+      ).to.deep.equal([4, 6]);
+    });
+
+    it('should apply the filter and return the list if map function is not given.', () => {
+      const list = ['Hello World', 'Hello Test', 'Hi Foo'];
+
+      expect(fmap(list, (x: string) => x.startsWith('Hello'))).to.deep.equal(['Hello World', 'Hello Test']);
+    });
+
+    it('should throw error if arguments are invalid.', () => {
+      expect(() => fmap('test' as any, a => a)).to.throw('The first argument must be an array.');
+      expect(() => fmap(['a', 'b'], 'abc' as any, b => b)).to.throw('Second argument must be a filter function.');
+      expect(() => fmap(['a', 'b'], a => a, 'abc' as any)).to.throw('Third argument must be a map function.');
+    });
+
+    it('should not mutate the passed list.', () => {
+      const list = [1, 2, 3, 4];
+
+      expect(list).to.deep.equal([1, 2, 3, 4]);
+    });
+  });
+});

--- a/test/util/list.test.ts
+++ b/test/util/list.test.ts
@@ -23,6 +23,12 @@ describe('UTIL: list', () => {
       expect(fmap(list, (x: string) => x.startsWith('Hello'))).to.deep.equal(['Hello World', 'Hello Test']);
     });
 
+    it('should just apply the map function and return the list if filter argument is false.', () => {
+      const list = ['hello', 'foo', 'bar'];
+
+      expect(fmap(list, false, (x: string) => x.toUpperCase())).to.deep.equal(['HELLO', 'FOO', 'BAR']);
+    });
+
     it('should throw error if arguments are invalid.', () => {
       expect(() => fmap('test' as any, a => a)).to.throw('The first argument must be an array.');
       expect(() => fmap(['a', 'b'], 'abc' as any, b => b)).to.throw('Second argument must be a filter function.');


### PR DESCRIPTION
**The most awaited feature**

- Introduce the `--only` CLI option to filter connections for a single connection id.
   * When provided, the command will be run for only that specific connection.
   * By default (when not provided), the command will run for all connections same as before.
   * The `only` option is also available for the Programmatic API usage.
- The option is supported in all of the commands: `synchronize`, `prune`, `migrate-latest`, `migrate-rollback`, `migrate-list`.

---
**Preview**

![image](https://user-images.githubusercontent.com/3315763/80305663-cb816b00-87dd-11ea-933c-93fb00c43092.png)

![image](https://user-images.githubusercontent.com/3315763/80305537-046d1000-87dd-11ea-97b9-57093f4e8a11.png)

![image](https://user-images.githubusercontent.com/3315763/80305544-0afb8780-87dd-11ea-8ea7-825c580b54e0.png)

