### PR TITLE
Make connections config consistent with Knex's config (breaking change)

### DIFF
--- a/examples/node-app-mssql/connections.sync-db.json.docker
+++ b/examples/node-app-mssql/connections.sync-db.json.docker
@@ -2,12 +2,14 @@
   "connections": [
     {
       "id": "testdb1",
-      "host": "mssql",
-      "port": 1433,
-      "user": "sa",
-      "database": "master",
-      "password": "Password@123",
-      "client": "mssql"
+      "client": "mssql",
+      "connection": {
+        "host": "mssql",
+        "port": 1433,
+        "user": "sa",
+        "database": "master",
+        "password": "Password@123"
+      }
     }
   ]
 }

--- a/examples/node-app-mssql/connections.sync-db.json.example
+++ b/examples/node-app-mssql/connections.sync-db.json.example
@@ -2,12 +2,14 @@
   "connections": [
     {
       "id": "testdb1",
-      "host": "localhost",
-      "port": 1433,
-      "user": "db1user",
-      "database": "testdb1",
-      "password": "password",
-      "client": "mssql"
+      "client": "mssql",
+      "connection": {
+        "host": "localhost",
+        "port": 1433,
+        "user": "db1user",
+        "database": "testdb1",
+        "password": "password"
+      }
     }
   ]
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,9 @@ import { mergeDeepRight } from 'ramda';
 import * as fs from './util/fs';
 import { log } from './util/logger';
 import { isObject } from './util/types';
-import DbConfig from './domain/DbConfig';
 import Configuration from './domain/Configuration';
 import ConnectionConfig from './domain/ConnectionConfig';
+import ConnectionsFileSchema from './domain/ConnectionsFileSchema';
 import { prepareInjectionConfigVars } from './service/configInjection';
 import { DEFAULT_CONFIG, CONFIG_FILENAME, CONNECTIONS_FILENAME, REQUIRED_ENV_KEYS } from './constants';
 
@@ -177,7 +177,7 @@ async function resolveConnectionsFromFile(filename: string): Promise<ConnectionC
   log('Resolving file: %s', filename);
 
   const loaded = await fs.read(filename);
-  const { connections } = JSON.parse(loaded) as DbConfig;
+  const { connections } = JSON.parse(loaded) as ConnectionsFileSchema;
 
   // TODO: Validate the connections received from file.
 

--- a/src/domain/ConnectionConfig.ts
+++ b/src/domain/ConnectionConfig.ts
@@ -3,16 +3,14 @@ import * as Knex from 'knex';
 /**
  * Database connection configuration.
  */
-type KnexConnections = Knex.ConnectionConfig &
-  Knex.MariaSqlConnectionConfig &
-  Knex.MySqlConnectionConfig &
-  Knex.MsSqlConnectionConfig &
-  Knex.SocketConnectionConfig &
-  Knex.Sqlite3ConnectionConfig;
-
-type ConnectionConfig = KnexConnections & {
+interface ConnectionConfig {
   id?: string;
   client: string;
-};
+  // This could be anything that Knex supports:
+  //  - a connection string
+  //  - a Knex.Config.connection config object
+  // Additionally, we also support providing a direct Knex connection instance for programmatic API.
+  connection: string | Knex | Knex.StaticConnectionConfig | Knex.ConnectionConfigProvider;
+}
 
 export default ConnectionConfig;

--- a/src/domain/ConnectionsFileSchema.ts
+++ b/src/domain/ConnectionsFileSchema.ts
@@ -3,8 +3,8 @@ import ConnectionConfig from './ConnectionConfig';
 /**
  * Interface for sync-db connection file (connections.sync-db.json).
  */
-interface DbConfig {
+interface ConnectionsFileSchema {
   connections: ConnectionConfig[];
 }
 
-export default DbConfig;
+export default ConnectionsFileSchema;

--- a/test/util/config.test.ts
+++ b/test/util/config.test.ts
@@ -34,15 +34,17 @@ describe('CONFIG:', () => {
       const connections = resolveConnectionsFromEnv();
 
       expect(connections[0]).to.deep.equal({
-        client: 'mssql',
         id: 'mydb',
-        host: 'localhost',
-        port: 1234,
-        user: 'user',
-        password: 'password',
-        database: 'database',
-        options: {
-          encrypt: false
+        client: 'mssql',
+        connection: {
+          host: 'localhost',
+          port: 1234,
+          user: 'user',
+          password: 'password',
+          database: 'database',
+          options: {
+            encrypt: false
+          }
         }
       });
 
@@ -95,10 +97,16 @@ describe('CONFIG:', () => {
     it('should generate a config id using the host and database name if id does not exist.', () => {
       expect(
         getConnectionId({
-          host: 'localhost',
-          database: 'test'
+          connection: {
+            host: 'localhost',
+            database: 'test'
+          }
         } as ConnectionConfig)
       ).to.equal('localhost/test');
+    });
+
+    it('should return empty string when id is not provided and connection string is passed.', () => {
+      expect(getConnectionId({ connection: 'someconnectionstring' } as ConnectionConfig)).to.equal('');
     });
   });
 });


### PR DESCRIPTION
**BREAKING CHANGE**
- Connection config is made identical to the Knex's config. The only difference is we use only handful of those `client` and `connection` and we add `id` attribute for our internal purpose.
- Being consistent with Knex is important because we want to support the things Knex add out of the box, as much as possible.
- Programmatic API usage will break too - it expects type `ConnectionConfig | ConnectionConfig[]`.

**Checklist**
- [x] Update and test node-app-mssql example
- [ ] Update and test programmatic usage example
- [ ] Update connection id auto-generation logic when not given - making it numeric might be the only way there.