### PR TITLE
Introduce make command to generate migration files

### DIFF
--- a/assets/templates/migration/create_down.sql
+++ b/assets/templates/migration/create_down.sql
@@ -1,0 +1,1 @@
+DROP TABLE {{table}};

--- a/assets/templates/migration/create_up.sql
+++ b/assets/templates/migration/create_up.sql
@@ -1,0 +1,6 @@
+--
+-- Create {{table}} table.
+--
+CREATE TABLE {{table}} (
+  id INT PRIMARY KEY
+);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "files": [
     "/bin/run",
     "/bin/run.cmd",
-    "/lib"
+    "/lib",
+    "/assets"
   ],
   "bin": {
     "sync-db": "./bin/run"

--- a/src/commands/make.ts
+++ b/src/commands/make.ts
@@ -1,8 +1,10 @@
 import { loadConfig } from '../config';
+import { printLine } from '../util/io';
 import { Command, flags } from '@oclif/command';
+import Configuration from '../domain/Configuration';
 import * as fileMakerService from '../service/fileMaker';
 
-class Prune extends Command {
+class Make extends Command {
   static description = 'Make migration files from the template.';
 
   static args = [{ name: 'name', description: 'Object or filename to generate.', required: true }];
@@ -22,18 +24,32 @@ class Prune extends Command {
    * @returns {Promise<void>}
    */
   async run(): Promise<void> {
-    const { args, flags: parsedFlags } = this.parse(Prune);
+    const { args, flags: parsedFlags } = this.parse(Make);
     const config = await loadConfig();
+    const list = await this.makeFiles(config, args.name, parsedFlags.type);
 
-    switch (parsedFlags.type) {
+    for (const filename of list) {
+      await printLine(`Created ${filename}`);
+    }
+  }
+
+  /**
+   * Make files based on the given name and type.
+   *
+   * @param {Configuration} config
+   * @param {string} name
+   * @param {string} [type]
+   * @returns {Promise<string[]>}
+   */
+  async makeFiles(config: Configuration, name: string, type?: string): Promise<string[]> {
+    switch (type) {
       case 'migration':
-        await fileMakerService.makeMigration(config, args.name);
-        break;
+        return fileMakerService.makeMigration(config, name);
 
       default:
-        throw new Error(`Unsupported file type ${parsedFlags.type}.`);
+        throw new Error(`Unsupported file type ${type}.`);
     }
   }
 }
 
-export default Prune;
+export default Make;

--- a/src/commands/make.ts
+++ b/src/commands/make.ts
@@ -1,0 +1,30 @@
+import { printLine } from '../util/io';
+import { Command, flags } from '@oclif/command';
+
+class Prune extends Command {
+  static description = 'Make migration files from the template.';
+
+  static args = [{ name: 'name', description: 'Object or filename to generate.', required: true }];
+  static flags = {
+    type: flags.string({
+      char: 't',
+      helpValue: 'TYPE',
+      description: 'Type of file to generate.',
+      default: 'migration',
+      options: ['migration', 'view', 'procedure', 'function']
+    })
+  };
+
+  /**
+   * CLI command execution handler.
+   *
+   * @returns {Promise<void>}
+   */
+  async run(): Promise<void> {
+    const { args, flags: parsedFlags } = this.parse(Prune);
+
+    printLine(JSON.stringify({ args, parsedFlags }));
+  }
+}
+
+export default Prune;

--- a/src/commands/make.ts
+++ b/src/commands/make.ts
@@ -1,5 +1,6 @@
-import { printLine } from '../util/io';
+import { loadConfig } from '../config';
 import { Command, flags } from '@oclif/command';
+import * as fileMakerService from '../service/fileMaker';
 
 class Prune extends Command {
   static description = 'Make migration files from the template.';
@@ -22,8 +23,16 @@ class Prune extends Command {
    */
   async run(): Promise<void> {
     const { args, flags: parsedFlags } = this.parse(Prune);
+    const config = await loadConfig();
 
-    printLine(JSON.stringify({ args, parsedFlags }));
+    switch (parsedFlags.type) {
+      case 'migration':
+        await fileMakerService.makeMigration(config, args.name);
+        break;
+
+      default:
+        throw new Error(`Unsupported file type ${parsedFlags.type}.`);
+    }
   }
 }
 

--- a/src/migration/service/knexMigrator.ts
+++ b/src/migration/service/knexMigrator.ts
@@ -80,12 +80,7 @@ export async function resolveMigrationContext(
 
   log(`Initialize migration context [sourceType=${config.migration.sourceType}]`);
 
-  const { basePath, migration } = config;
-
-  // Migration directory could be absolute OR could be relative to the basePath.
-  const migrationPath = path.isAbsolute(migration.directory)
-    ? migration.directory
-    : path.join(basePath, migration.directory);
+  const migrationPath = getMigrationPath(config);
 
   switch (config.migration.sourceType) {
     case 'sql':
@@ -100,4 +95,20 @@ export async function resolveMigrationContext(
       // For instance migrations in JS would have different context like JavaScriptMigrationContext.
       throw new Error(`Unsupported migration.sourceType value "${config.migration.sourceType}".`);
   }
+}
+
+/**
+ * Get Migration directory path.
+ *
+ * @param {Configuration} config
+ * @returns {string}
+ */
+export function getMigrationPath(config: Configuration): string {
+  const { basePath, migration } = config;
+  // Migration directory could be absolute OR could be relative to the basePath.
+  const migrationPath = path.isAbsolute(migration.directory)
+    ? migration.directory
+    : path.join(basePath, migration.directory);
+
+  return migrationPath;
 }

--- a/src/service/fileMaker.ts
+++ b/src/service/fileMaker.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import * as fs from '../util/fs';
+import { getTimestampString } from '../util/ts';
 import Configuration from '../domain/Configuration';
 import { getMigrationPath } from '../migration/service/knexMigrator';
 
@@ -23,7 +24,7 @@ export async function makeMigration(config: Configuration, filename: string): Pr
   const createUpTemplate = await fs.read(path.join(migrationTemplatePath, 'create_up.sql'));
   const createDownTemplate = await fs.read(path.join(migrationTemplatePath, 'create_down.sql'));
 
-  const timestamp = '20200503200303';
+  const timestamp = getTimestampString();
   const upFilename = path.join(migrationPath, `${timestamp}_${filename}.up.sql`);
   const downFilename = path.join(migrationPath, `${timestamp}_${filename}.down.sql`);
 

--- a/src/service/fileMaker.ts
+++ b/src/service/fileMaker.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import * as fs from '../util/fs';
+import { log } from '../util/logger';
 import { getTimestampString } from '../util/ts';
 import Configuration from '../domain/Configuration';
 import { getMigrationPath } from '../migration/service/knexMigrator';
@@ -21,6 +22,14 @@ export async function makeMigration(config: Configuration, filename: string): Pr
   }
 
   const migrationPath = getMigrationPath(config);
+  const migrationPathExists = await fs.exists(migrationPath);
+
+  if (!migrationPathExists) {
+    log(`Migration path does not exist, creating ${migrationPath}`);
+
+    await fs.mkdir(migrationPath, { recursive: true });
+  }
+
   const createUpTemplate = await fs.read(path.join(migrationTemplatePath, 'create_up.sql'));
   const createDownTemplate = await fs.read(path.join(migrationTemplatePath, 'create_down.sql'));
 

--- a/src/service/fileMaker.ts
+++ b/src/service/fileMaker.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import * as fs from '../util/fs';
 import Configuration from '../domain/Configuration';
 import { getMigrationPath } from '../migration/service/knexMigrator';
-import { printLine } from '../util/io';
 
 const migrationTemplatePath = path.resolve(__dirname, '../../assets/templates/migration');
 
@@ -31,6 +30,5 @@ export async function makeMigration(config: Configuration, filename: string): Pr
   await fs.write(upFilename, createUpTemplate);
   await fs.write(downFilename, createDownTemplate);
 
-  await printLine(`Created ${upFilename}`);
-  await printLine(`Created ${downFilename}`);
+  return [upFilename, downFilename];
 }

--- a/src/service/fileMaker.ts
+++ b/src/service/fileMaker.ts
@@ -2,11 +2,12 @@ import * as path from 'path';
 
 import * as fs from '../util/fs';
 import { log } from '../util/logger';
+import { interpolate } from '../util/string';
 import { getTimestampString } from '../util/ts';
 import Configuration from '../domain/Configuration';
 import { getMigrationPath } from '../migration/service/knexMigrator';
 
-const MIGRATION_TMPL_PATH = path.resolve(__dirname, '../../assets/templates/migration');
+const MIGRATION_TEMPLATE_PATH = path.resolve(__dirname, '../../assets/templates/migration');
 const CREATE_TABLE_CONVENTION = /create_(\w+)_table/;
 
 /**
@@ -45,15 +46,13 @@ export async function makeMigration(config: Configuration, filename: string): Pr
     const table = createTableMatched[1];
 
     log(`Create migration for table: ${table}`);
-    console.log('Table: ', table); // tslint:disable-line
 
-    // TODO: Use interpolation function.
     createUpTemplate = await fs
-      .read(path.join(MIGRATION_TMPL_PATH, 'create_up.sql'))
-      .then(template => template.replace(new RegExp('{{table}}', 'g'), table));
+      .read(path.join(MIGRATION_TEMPLATE_PATH, 'create_up.sql'))
+      .then(template => interpolate(template, { table }));
     createDownTemplate = await fs
-      .read(path.join(MIGRATION_TMPL_PATH, 'create_down.sql'))
-      .then(template => template.replace(new RegExp('{{table}}', 'g'), table));
+      .read(path.join(MIGRATION_TEMPLATE_PATH, 'create_down.sql'))
+      .then(template => interpolate(template, { table }));
   }
 
   await fs.write(upFilename, createUpTemplate);

--- a/src/service/fileMaker.ts
+++ b/src/service/fileMaker.ts
@@ -6,7 +6,7 @@ import { getTimestampString } from '../util/ts';
 import Configuration from '../domain/Configuration';
 import { getMigrationPath } from '../migration/service/knexMigrator';
 
-const migrationTemplatePath = path.resolve(__dirname, '../../assets/templates/migration');
+// const migrationTemplatePath = path.resolve(__dirname, '../../assets/templates/migration');
 
 /**
  * Generate migration file(s).
@@ -30,15 +30,16 @@ export async function makeMigration(config: Configuration, filename: string): Pr
     await fs.mkdir(migrationPath, { recursive: true });
   }
 
-  const createUpTemplate = await fs.read(path.join(migrationTemplatePath, 'create_up.sql'));
-  const createDownTemplate = await fs.read(path.join(migrationTemplatePath, 'create_down.sql'));
+  // TODO: Implement this.
+  // const createUpTemplate = await fs.read(path.join(migrationTemplatePath, 'create_up.sql'));
+  // const createDownTemplate = await fs.read(path.join(migrationTemplatePath, 'create_down.sql'));
 
   const timestamp = getTimestampString();
   const upFilename = path.join(migrationPath, `${timestamp}_${filename}.up.sql`);
   const downFilename = path.join(migrationPath, `${timestamp}_${filename}.down.sql`);
 
-  await fs.write(upFilename, createUpTemplate);
-  await fs.write(downFilename, createDownTemplate);
+  await fs.write(upFilename, '');
+  await fs.write(downFilename, '');
 
   return [upFilename, downFilename];
 }

--- a/src/service/fileMaker.ts
+++ b/src/service/fileMaker.ts
@@ -1,0 +1,36 @@
+import * as path from 'path';
+
+import * as fs from '../util/fs';
+import Configuration from '../domain/Configuration';
+import { getMigrationPath } from '../migration/service/knexMigrator';
+import { printLine } from '../util/io';
+
+const migrationTemplatePath = path.resolve(__dirname, '../../assets/templates/migration');
+
+/**
+ * Generate migration file(s).
+ *
+ * @param {string} filename
+ * @returns {Promise<string[]>}
+ */
+export async function makeMigration(config: Configuration, filename: string): Promise<string[]> {
+  if (config.migration.sourceType !== 'sql') {
+    // TODO: We'll need to support different types of migrations eg both sql & js
+    // For instance migrations in JS would have different context like JavaScriptMigrationContext.
+    throw new Error(`Unsupported migration.sourceType value "${config.migration.sourceType}".`);
+  }
+
+  const migrationPath = getMigrationPath(config);
+  const createUpTemplate = await fs.read(path.join(migrationTemplatePath, 'create_up.sql'));
+  const createDownTemplate = await fs.read(path.join(migrationTemplatePath, 'create_down.sql'));
+
+  const timestamp = '20200503200303';
+  const upFilename = path.join(migrationPath, `${timestamp}_${filename}.up.sql`);
+  const downFilename = path.join(migrationPath, `${timestamp}_${filename}.down.sql`);
+
+  await fs.write(upFilename, createUpTemplate);
+  await fs.write(downFilename, createDownTemplate);
+
+  await printLine(`Created ${upFilename}`);
+  await printLine(`Created ${downFilename}`);
+}

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -3,6 +3,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
 
+export const mkdir = promisify(fs.mkdir);
+
 /**
  * Create a temporary directory and return it's path.
  *

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -5,7 +5,7 @@
  *  {{name}}
  *
  * @example
- * interpolate('<div>>{{text}}</div>', {text: 'Hello World!'})
+ * interpolate('<div>{{text}}</div>', {text: 'Hello World!'})
  *  => '<div>Hello World!</div>'
  *
  * @param {string} template

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -1,0 +1,31 @@
+/**
+ * Interpolate a given template string by filling the placeholders with the params.
+ *
+ * Placeholder syntax:
+ *  {{name}}
+ *
+ * @example
+ * interpolate('<div>>{{text}}</div>', {text: 'Hello World!'})
+ *  => '<div>Hello World!</div>'
+ *
+ * @param {string} template
+ * @param {*} [params={}]
+ * @returns {string}
+ */
+export function interpolate(template: string, params: any = {}): string {
+  if (!params || !Object.keys(params)) {
+    return template;
+  }
+
+  let result = template;
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+
+    result = result.replace(new RegExp('{{' + key + '}}', 'g'), `${value}`);
+  }
+
+  return result;
+}

--- a/src/util/ts.ts
+++ b/src/util/ts.ts
@@ -17,3 +17,36 @@ export function getElapsedTime(timeStart: [number, number], fixed: false | numbe
 
   return Number(timeElapsed.toFixed(fixed));
 }
+
+/**
+ * Gets a timestamp string for the given date.
+ *
+ * @param {Date} [date=new Date()]
+ * @returns {string}
+ */
+export function getTimestampString(date: Date = new Date()): string {
+  const dtf = new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+
+  const [
+    { value: month },
+    ,
+    { value: day },
+    ,
+    { value: year },
+    ,
+    { value: hour },
+    ,
+    { value: minute },
+    ,
+    { value: second }
+  ] = dtf.formatToParts(date);
+
+  return `${year}${month}${day}${hour}${minute}${second}`;
+}

--- a/test/cli/commands/common.test.ts
+++ b/test/cli/commands/common.test.ts
@@ -11,7 +11,7 @@ const packageJson = fs.readFileSync(path.join(__dirname, '../../../package.json'
 const { version } = JSON.parse(packageJson.toString());
 
 describe('CLI:', () => {
-  describe('default run', () => {
+  describe('with no args', () => {
     it('should display the usage information.', async () => {
       const { stdout } = await runCli([], { cwd });
 

--- a/test/cli/commands/make.test.ts
+++ b/test/cli/commands/make.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import { it, describe } from 'mocha';
+
+import { runCli } from './util';
+import { mkdtempSync } from '../../../src/util/fs';
+
+const cwd = mkdtempSync();
+
+describe('CLI: make', () => {
+  describe('--help', () => {
+    it('should print help message.', async () => {
+      const { stdout } = await runCli(['make', '--help'], { cwd });
+
+      expect(stdout).contains('make');
+      expect(stdout).contains(`USAGE\n  $ sync-db make`);
+    });
+  });
+});

--- a/test/cli/commands/make.test.ts
+++ b/test/cli/commands/make.test.ts
@@ -1,18 +1,57 @@
+import * as path from 'path';
+import * as yaml from 'yamljs';
 import { expect } from 'chai';
 import { it, describe } from 'mocha';
 
 import { runCli } from './util';
-import { mkdtempSync } from '../../../src/util/fs';
-
-const cwd = mkdtempSync();
+import { mkdir, mkdtemp, write } from '../../../src/util/fs';
+import Configuration from '../../../src/domain/Configuration';
 
 describe('CLI: make', () => {
   describe('--help', () => {
     it('should print help message.', async () => {
-      const { stdout } = await runCli(['make', '--help'], { cwd });
+      const { stdout } = await runCli(['make', '--help']);
 
       expect(stdout).contains('make');
       expect(stdout).contains(`USAGE\n  $ sync-db make`);
     });
+  });
+
+  it('should create a migration file when only name is supplied.', async () => {
+    // Write sync-db.yml file.
+    const cwd = await mkdtemp();
+    await mkdir(path.join(cwd, 'src/migration'), { recursive: true });
+    await write(
+      path.join(cwd, 'sync-db.yml'),
+      yaml.stringify({
+        migration: {
+          directory: 'migration'
+        }
+      } as Configuration)
+    );
+
+    const { stdout } = await runCli(['make', 'create_test_table'], { cwd });
+
+    // Files are created.
+    expect(stdout).to.match(/Created.+\d{13}_create_test_table\.up\.sql/);
+    expect(stdout).to.match(/Created.+\d{13}_create_test_table\.down\.sql/);
+  });
+
+  it('should create migration directory automatically if it does not exist.', async () => {
+    const cwd = await mkdtemp();
+    await write(
+      path.join(cwd, 'sync-db.yml'),
+      yaml.stringify({
+        migration: {
+          directory: 'migration'
+        }
+      } as Configuration)
+    );
+
+    const { stdout } = await runCli(['make', 'create_test_table'], { cwd });
+
+    // Files are created.
+    expect(stdout).to.match(/Created.+\d{13}_create_test_table\.up\.sql/);
+    expect(stdout).to.match(/Created.+\d{13}_create_test_table\.down\.sql/);
   });
 });

--- a/test/cli/commands/make.test.ts
+++ b/test/cli/commands/make.test.ts
@@ -43,19 +43,23 @@ describe('CLI: make', () => {
       } as Configuration)
     );
 
-    const { stdout } = await runCli(['make', 'something'], { cwd });
+    const { stdout } = await runCli(['make', 'alter_users_table_drop_column'], { cwd });
 
     // Check the output.
-    expect(stdout).to.match(/Created.+\d{13}_something\.up\.sql/);
-    expect(stdout).to.match(/Created.+\d{13}_something\.down\.sql/);
+    expect(stdout).to.match(/Created.+\d{13}_alter_users_table_drop_column\.up\.sql/);
+    expect(stdout).to.match(/Created.+\d{13}_alter_users_table_drop_column\.down\.sql/);
 
     // Check files are created.
     const files = await glob(migrationPath);
 
     expect(files.length).to.equal(2);
 
-    const upFile = await read(path.join(migrationPath, queryByPattern(files, /\d{13}_something\.up\.sql/)));
-    const downFile = await read(path.join(migrationPath, queryByPattern(files, /\d{13}_something\.down\.sql/)));
+    const upFile = await read(
+      path.join(migrationPath, queryByPattern(files, /\d{13}_alter_users_table_drop_column\.up\.sql/))
+    );
+    const downFile = await read(
+      path.join(migrationPath, queryByPattern(files, /\d{13}_alter_users_table_drop_column\.down\.sql/))
+    );
 
     expect(upFile).to.equal('');
     expect(downFile).to.equal('');

--- a/test/cli/commands/util.ts
+++ b/test/cli/commands/util.ts
@@ -15,10 +15,18 @@ export function runCli(args?: string[], options?: execa.Options<string>): execa.
 }
 
 /**
- * Check if the list contains at least one value that matches the pattern.
+ * Query a list by regex pattern and return the found value.
+ *
+ * @param {string[]} list
+ * @param {RegExp} pattern
+ * @returns {string}
  */
-export function listContainsPattern(list: string[], pattern: RegExp): boolean {
-  const matches = list.filter(item => pattern.test(item));
+export function queryByPattern(list: string[], pattern: RegExp): string {
+  const found = list.find(item => pattern.test(item));
 
-  return matches.length > 0;
+  if (!found) {
+    throw new Error(`Pattern ${pattern} not found in the list ${list}.`);
+  }
+
+  return found;
 }

--- a/test/cli/commands/util.ts
+++ b/test/cli/commands/util.ts
@@ -13,3 +13,12 @@ const binPath = getBinPathSync();
 export function runCli(args?: string[], options?: execa.Options<string>): execa.ExecaChildProcess<any> {
   return execa(binPath, args, options);
 }
+
+/**
+ * Check if the list contains at least one value that matches the pattern.
+ */
+export function listContainsPattern(list: string[], pattern: RegExp): boolean {
+  const matches = list.filter(item => pattern.test(item));
+
+  return matches.length > 0;
+}

--- a/test/unit/util/string.test.ts
+++ b/test/unit/util/string.test.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { interpolate } from '../../../src/util/string';
+
+describe('UTIL: string', () => {
+  describe('interpolate', () => {
+    it('should replace the template placeholders with params.', () => {
+      expect(
+        interpolate('<div class="{{className}}">{{text}}</div>', {
+          className: 'test',
+          text: 'Hello World!'
+        })
+      ).to.equal('<div class="test">Hello World!</div>');
+    });
+
+    it('should leave the unresolved placeholders as-is.', () => {
+      expect(
+        interpolate('Hello {{user}}! This is {{foo}}.', {
+          user: 'Kabir'
+        })
+      ).to.equal('Hello Kabir! This is {{foo}}.');
+    });
+  });
+});

--- a/test/unit/util/ts.test.ts
+++ b/test/unit/util/ts.test.ts
@@ -9,19 +9,20 @@ describe('UTIL: ts', () => {
       const result1 = ts.getTimestampString(new Date('December 17, 1995 03:24:00'));
       const result2 = ts.getTimestampString(new Date('December 17, 1995 15:24:00'));
 
-      expect(result1).to.equal('1995121732400');
-      expect(result2).to.equal('1995121732400');
+      expect(result1).to.equal('19951217032400');
+      expect(result2).to.equal('19951217032400');
     });
 
     it('should return a timestamp string with the current date if date is not provided.', () => {
+      const now = new Date();
       const result = ts.getTimestampString();
 
-      expect(result.startsWith(new Date().getFullYear().toString()));
-      expect(result.length).to.equal(13);
+      expect(result.startsWith(now.getFullYear().toString()));
+      expect(result.length).to.equal(14);
     });
 
     it('should return a value fully numeric.', () => {
-      expect(ts.getTimestampString()).to.match(/^\d+$/);
+      expect(ts.getTimestampString()).to.match(/^\d{14}$/);
     });
   });
 });

--- a/test/unit/util/ts.test.ts
+++ b/test/unit/util/ts.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { it, describe } from 'mocha';
+
+import * as ts from '../../../src/util/ts';
+
+describe('UTIL: ts', () => {
+  describe('getTimestampString', () => {
+    it('should return a timestamp string for the given date instance.', () => {
+      const result1 = ts.getTimestampString(new Date('December 17, 1995 03:24:00'));
+      const result2 = ts.getTimestampString(new Date('December 17, 1995 15:24:00'));
+
+      expect(result1).to.equal('1995121732400');
+      expect(result2).to.equal('1995121732400');
+    });
+
+    it('should return a timestamp string with the current date if date is not provided.', () => {
+      const result = ts.getTimestampString();
+
+      expect(result.startsWith(new Date().getFullYear().toString()));
+      expect(result.length).to.equal(13);
+    });
+
+    it('should return a value fully numeric.', () => {
+      expect(ts.getTimestampString()).to.match(/^\d+$/);
+    });
+  });
+});


### PR DESCRIPTION
### The make command
* Introduce `make` command to generate migration files.
* If it receives an argument in the form `create_<something>_table` then it will use the create table template for the file otherwise blank migration files are generated.
* In future it could support creating other DB objects like views, functions, etc with an optional option `--type` given

### Other chnages
* Add ts utili function, few more tests
* Remove CLI tests from test coverage - it's not needed and it took very long time for the tests.

### Preview
```
$ sync-db make create_test_table
```
![image](https://user-images.githubusercontent.com/3315763/83967280-b4a35d80-a8df-11ea-9b3c-97da31306abe.png)

```
$ sync-db make somethingelse
```
![image](https://user-images.githubusercontent.com/3315763/83967317-faf8bc80-a8df-11ea-8367-530581031045.png)

