### PR TITLE
Support connection resolver

### DIFF
--- a/src/commands/migrate-latest.ts
+++ b/src/commands/migrate-latest.ts
@@ -14,6 +14,10 @@ class MigrateLatest extends Command {
     only: flags.string({
       helpValue: 'CONNECTION_ID',
       description: 'Filter only a single connection.'
+    }),
+    'connection-resolver': flags.string({
+      helpValue: 'PATH',
+      description: 'Path to the connection resolver.'
     })
   };
 
@@ -60,7 +64,7 @@ class MigrateLatest extends Command {
   async run(): Promise<void> {
     const { flags: parsedFlags } = this.parse(MigrateLatest);
     const config = await loadConfig();
-    const connections = await resolveConnections();
+    const connections = await resolveConnections(config, parsedFlags['connection-resolver']);
 
     const results = await migrateLatest(config, connections, {
       ...parsedFlags,

--- a/src/commands/migrate-list.ts
+++ b/src/commands/migrate-list.ts
@@ -13,6 +13,10 @@ class MigrateList extends Command {
     only: flags.string({
       helpValue: 'CONNECTION_ID',
       description: 'Filter only a single connection.'
+    }),
+    'connection-resolver': flags.string({
+      helpValue: 'PATH',
+      description: 'Path to the connection resolver.'
     })
   };
 
@@ -64,7 +68,7 @@ class MigrateList extends Command {
   async run(): Promise<void> {
     const { flags: parsedFlags } = this.parse(MigrateList);
     const config = await loadConfig();
-    const connections = await resolveConnections();
+    const connections = await resolveConnections(config, parsedFlags['connection-resolver']);
 
     const results = await migrateList(config, connections, {
       ...parsedFlags,

--- a/src/commands/migrate-rollback.ts
+++ b/src/commands/migrate-rollback.ts
@@ -14,6 +14,10 @@ class MigrateRollback extends Command {
     only: flags.string({
       helpValue: 'CONNECTION_ID',
       description: 'Filter only a single connection.'
+    }),
+    'connection-resolver': flags.string({
+      helpValue: 'PATH',
+      description: 'Path to the connection resolver.'
     })
   };
 
@@ -60,7 +64,7 @@ class MigrateRollback extends Command {
   async run(): Promise<void> {
     const { flags: parsedFlags } = this.parse(MigrateRollback);
     const config = await loadConfig();
-    const connections = await resolveConnections();
+    const connections = await resolveConnections(config, parsedFlags['connection-resolver']);
 
     const results = await migrateRollback(config, connections, {
       ...parsedFlags,

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -13,6 +13,10 @@ class Prune extends Command {
     only: flags.string({
       helpValue: 'CONNECTION_ID',
       description: 'Filter only a single connection.'
+    }),
+    'connection-resolver': flags.string({
+      helpValue: 'PATH',
+      description: 'Path to the connection resolver.'
     })
   };
 
@@ -40,7 +44,7 @@ class Prune extends Command {
   async run(): Promise<void> {
     const { flags: parsedFlags } = this.parse(Prune);
     const config = await loadConfig();
-    const connections = await resolveConnections();
+    const connections = await resolveConnections(config, parsedFlags['connection-resolver']);
 
     const results = await prune(config, connections, {
       ...parsedFlags,

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -15,11 +15,15 @@ class Synchronize extends Command {
    * Available CLI flags.
    */
   static flags = {
-    force: flags.boolean({ char: 'f', description: 'Force synchronization' }),
-    'skip-migration': flags.boolean({ description: 'Skip running migrations' }),
+    force: flags.boolean({ char: 'f', description: 'Force synchronization.' }),
+    'skip-migration': flags.boolean({ description: 'Skip running migrations.' }),
     only: flags.string({
       helpValue: 'CONNECTION_ID',
       description: 'Filter only a single connection.'
+    }),
+    'connection-resolver': flags.string({
+      helpValue: 'PATH',
+      description: 'Path to the connection resolver.'
     })
   };
 

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -131,7 +131,7 @@ class Synchronize extends Command {
 
     try {
       const config = await loadConfig();
-      const connections = await resolveConnections();
+      const connections = await resolveConnections(config, parsedFlags['connection-resolver']);
       const timeStart = process.hrtime();
 
       await printLine('Synchronizing...\n');

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,8 +101,10 @@ export async function resolveConnections(config: Configuration, resolver?: strin
 
   let connections: ConnectionConfig[];
 
-  // If connections file exists, resolve connections from that.
-  // otherwise fallback to getting the connection from the env vars.
+  // Connection resolution process:
+  //  1. If connections file exists, use that to resolve connections.
+  //  2. If connection resolver is set via flag or configuration, use it.
+  //  3. If 1 & 2 are false, try resolving the connections from the environment. If not found fail with error.
   if (connectionsFileExists) {
     connections = await resolveConnectionsFromFile(filename);
   } else if (resolver) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export const CONNECTIONS_FILENAME = 'connections.sync-db.json';
 export const INJECTED_CONFIG_TABLE = '__sync_db_injected_config';
 export const DEFAULT_CONFIG: Configuration = {
   basePath: path.resolve(process.cwd(), 'src'),
+  connectionResolver: '',
   execution: 'parallel',
   sql: [],
   hooks: {

--- a/src/domain/Configuration.ts
+++ b/src/domain/Configuration.ts
@@ -7,6 +7,7 @@ interface Configuration {
   basePath: string;
   execution: 'parallel' | 'sequential';
   sql: string[];
+  connectionResolver: string;
   hooks: {
     pre_sync: string[];
     post_sync: string[];


### PR DESCRIPTION
Resolves https://github.com/leapfrogtechnology/sync-db/issues/32

* Ability to use connection resolver via `--connection-resolver` option or `connectionResolver` configuration option in the `sync-db.yml` file. 
* Connection resolver is a javascript module that exposes a `resolve` function which resolves a list of database connection just in the same form as `connections.sync-db.json` file.
* Useful when you need to get the connections dynamically or from a separate service eg: vault, AWS secret manager, API etc. 
* Connection resolution process and order:
      1. If connections file exists, use that to resolve connections.
      2. If connection resolver is set via flag or configuration, use it.
      3. If 1 & 2 are false, try resolving the connections from the environment. If not found fail with error.
* See #32 for details.

