### PR TITLE
Remove short character (-f) command for dry-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/commands/migrate-latest.ts
+++ b/src/commands/migrate-latest.ts
@@ -11,7 +11,7 @@ class MigrateLatest extends Command {
   static description = 'Run the migrations up to the latest changes.';
 
   static flags = {
-    'dry-run': flags.boolean({ char: 'f', description: 'Dry Run migration.', default: false }),
+    'dry-run': flags.boolean({ description: 'Dry run migration.', default: false }),
     only: flags.string({
       helpValue: 'CONNECTION_ID',
       description: 'Filter only a single connection.'

--- a/src/commands/migrate-rollback.ts
+++ b/src/commands/migrate-rollback.ts
@@ -11,7 +11,7 @@ class MigrateRollback extends Command {
   static description = 'Rollback migrations up to the last run batch.';
 
   static flags = {
-    'dry-run': flags.boolean({ char: 'f', description: 'Dry Run migration rollback.', default: false }),
+    'dry-run': flags.boolean({ description: 'Dry run rollback.', default: false }),
     only: flags.string({
       helpValue: 'CONNECTION_ID',
       description: 'Filter only a single connection.'

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -10,7 +10,7 @@ class Prune extends Command {
   static description = 'Drop all the synchronized db objects except the ones created via migrations.';
 
   static flags = {
-    'dry-run': flags.boolean({ char: 'f', description: 'Dry Run Prune.', default: false }),
+    'dry-run': flags.boolean({ description: 'Dry run prune.', default: false }),
     only: flags.string({
       helpValue: 'CONNECTION_ID',
       description: 'Filter only a single connection.'

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -16,7 +16,7 @@ class Synchronize extends Command {
    */
   static flags = {
     force: flags.boolean({ char: 'f', description: 'Force synchronization.' }),
-    'dry-run': flags.boolean({ char: 'f', description: 'Dry Run synchronization.', default: false }),
+    'dry-run': flags.boolean({ description: 'Dry run synchronization.', default: false }),
     'skip-migration': flags.boolean({ description: 'Skip running migrations.' }),
     only: flags.string({
       helpValue: 'CONNECTION_ID',


### PR DESCRIPTION
Remove short character command for dry-run

```
➜  sync-db/examples/node-app-pg remove-dry-run-short-char ✓ yarn sync-db synchronize --help
yarn run v1.22.10
$ sync-db synchronize --help
Synchronize all the configured database connections.

USAGE
  $ sync-db synchronize

OPTIONS
  -f, --force                 Force synchronization.
  --connection-resolver=PATH  Path to the connection resolver.
  --dry-run                   Dry run synchronization.
  --only=CONNECTION_ID        Filter only a single connection.
  --skip-migration            Skip running migrations.
```