### PR TITLE
Add includeExtension option in migration specific configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ sql:
 - **`migration`** `(array)` - Migrations specific configurations.
 
   - **`sourceType`** `(string)` - Type of migration file. Value `defaults` to sql. - **example**: javascript, typescript.
-  - **`tableName`** `(string)` - Custom name for table to store migrations meta data.
+  - **`tableName`** `(string)` - Custom name for table to store migrations meta data. (Default: `knex_migrations`)
+  - **`includeExtension`** `(boolean)` - Include migration file extension (`.js` or `.ts`) in migrations table for `sourceType` value `javascript` and `typescript`. (Default: `false`)
 
 - **`connectionResolver`** (`string`) - Connection resolver file name optional if connections are resolved using `connections.sync-db.json`.
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,8 @@ export const DEFAULT_CONFIG: Configuration = {
   migration: {
     directory: 'migration',
     tableName: 'knex_migrations', // Note: This is Knex's default value. Just keeping it same.
-    sourceType: 'sql'
+    sourceType: 'sql',
+    includeExtension: false
   }
 };
 

--- a/src/domain/Configuration.ts
+++ b/src/domain/Configuration.ts
@@ -20,6 +20,7 @@ interface Configuration {
     tableName: string;
     // TODO: Only 'sql' is supported sourceType now. JS will be supported later.
     sourceType: 'sql' | 'javascript' | 'typescript';
+    includeExtension: boolean;
   };
 }
 

--- a/src/migration/service/knexMigrator.ts
+++ b/src/migration/service/knexMigrator.ts
@@ -93,14 +93,22 @@ export async function resolveMigrationContext(
       return new SqlMigrationSourceContext(src);
 
     case 'javascript':
-      const srcJS = await resolveJavaScriptMigrations(migrationPath, FileExtensions.JS, config.migration.includeExtension);
+      const srcJS = await resolveJavaScriptMigrations(
+        migrationPath,
+        FileExtensions.JS,
+        config.migration.includeExtension
+      );
 
       log('Available migration sources:\n%O', srcJS);
 
       return new JavaScriptMigrationContext(srcJS);
 
     case 'typescript':
-      const srcTS = await resolveJavaScriptMigrations(migrationPath, FileExtensions.TS, config.migration.includeExtension);
+      const srcTS = await resolveJavaScriptMigrations(
+        migrationPath,
+        FileExtensions.TS,
+        config.migration.includeExtension
+      );
 
       log('Available migration sources:\n%O', srcTS);
 

--- a/src/migration/service/knexMigrator.ts
+++ b/src/migration/service/knexMigrator.ts
@@ -93,14 +93,14 @@ export async function resolveMigrationContext(
       return new SqlMigrationSourceContext(src);
 
     case 'javascript':
-      const srcJS = await resolveJavaScriptMigrations(migrationPath);
+      const srcJS = await resolveJavaScriptMigrations(migrationPath, FileExtensions.JS, config.migration.includeExtension);
 
       log('Available migration sources:\n%O', srcJS);
 
       return new JavaScriptMigrationContext(srcJS);
 
     case 'typescript':
-      const srcTS = await resolveJavaScriptMigrations(migrationPath, FileExtensions.TS);
+      const srcTS = await resolveJavaScriptMigrations(migrationPath, FileExtensions.TS, config.migration.includeExtension);
 
       log('Available migration sources:\n%O', srcTS);
 

--- a/src/migration/service/migrator.ts
+++ b/src/migration/service/migrator.ts
@@ -90,12 +90,14 @@ export async function resolveSqlMigrations(migrationPath: string): Promise<SqlMi
  * Resolve all the migration source for each of the migration entries using the configurations.
  *
  * @param {string} migrationPath
- * @param {string} extension
- * @returns {Promise<SqlMigrationEntry[]>}
+ * @param {string=FileExtensions.JS} extension
+ * @param {boolean=false} includeExtension
+ * @returns {Promise<JavaScriptMigrationEntry[]>}
  */
 export async function resolveJavaScriptMigrations(
   migrationPath: string,
-  extension: string = FileExtensions.JS
+  extension: string = FileExtensions.JS,
+  includeExtension: boolean = false
 ): Promise<JavaScriptMigrationEntry[]> {
   const migrationNames = await getJavaScriptMigrationNames(migrationPath, extension);
 
@@ -117,7 +119,7 @@ export async function resolveJavaScriptMigrations(
     const { up, down } = mRequire(path.resolve(migrationPath, filename));
 
     return {
-      name,
+      name: includeExtension ? filename : name,
       methods: {
         up,
         down


### PR DESCRIPTION
**Problem:**

The problem was identified while replacing the knex migrator with sync-db migrator.

Reason: sync-db migrator removes the extension (`.ts, .js`) from filename while inserting in the migrations table but `Knex` migrator by default includes an extension. This corrupts the existing migrations because of the mismatched filename and migrations' table value.

| Knex Migrations Table | sync-db Migrations Table |
| -- | -- |
| 20170918131001_create_employees_table.ts | 20170918131001_create_employees_table |

**Solution:**

For `sourceType` value `javascript` and `typescript`, added `includedExtension` to customize the including/excluding extension.

```diff
  migration:
    directory: 'migration',
    tableName: 'knex_migrations', // Note: This is Knex's default value. Just keeping it same.
    sourceType: 'javascript',
+   includeExtension: true
```

