### PR TITLE
Fix migration issue by including file extension

### DIFF
--- a/src/migration/service/migrator.ts
+++ b/src/migration/service/migrator.ts
@@ -117,7 +117,7 @@ export async function resolveJavaScriptMigrations(
     const { up, down } = mRequire(path.resolve(migrationPath, filename));
 
     return {
-      name,
+      name: filename,
       methods: {
         up,
         down

--- a/test/unit/migration/migrator.test.ts
+++ b/test/unit/migration/migrator.test.ts
@@ -211,12 +211,12 @@ describe('MIGRATION: migrator', () => {
 
       // Test the migrations entries retrieved from the directory.
       expect(result.length).to.equal(1);
-      expect(result[0].name).to.deep.equal('0001_create_table_users');
+      expect(result[0].name).to.deep.equal('0001_create_table_users.js');
       expect(result[0].methods.up.name).to.deep.equal('up');
       expect(result[0].methods.down.name).to.deep.equal('down');
 
       expect(result1.length).to.equal(1);
-      expect(result1[0].name).to.deep.equal('0002_alter_table_users_add_gender');
+      expect(result1[0].name).to.deep.equal('0002_alter_table_users_add_gender.ts');
       expect(result1[0].methods.up.name).to.deep.equal('up');
       expect(result1[0].methods.down.name).to.deep.equal('down');
     });


### PR DESCRIPTION
**Issue:**

The problem was identified while replacing the knex migrator with sync-db migrator.

Reason: sync-db migrator removes the extension (`.ts, .js`) from filename while inserting in the migrations table but `Knex` migrator by default includes an extension. This corrupts the existing migrations because of the mismatched filename and migrations' table value.

| Knex Migrations Table | sync-db Migrations Table |
| -- | -- |
| 20170918131001_create_employees_table.ts | 20170918131001_create_employees_table |

**Solution**

Passing the full filename including an extension in migration object.

