### PR TITLE
Fix parallel strategy test case and release.sh script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -41,20 +41,12 @@ bump() {
 }
 
 compare_and_release() {
-  ## Compare the package.json file from two recent commits to master branch and export
+  ## Compare the package.json file from published package to master branch and export
   ## value to NEXT variable if it differs.
 
-  # Get the second last commit from the master branch after merge.
-  previous_commit_hash=$(git rev-parse @~)
-
-  git fetch --all
-  git checkout ${previous_commit_hash}
-
-  old_version=$(cat package.json | jq -r ".version")
+  old_version=$(npm show @leapfrogtechnology/sync-db version)
 
   printfln "Old package version: ${old_version}"
-
-  git checkout master
 
   new_version=$(cat package.json | jq -r ".version")
 

--- a/release.sh
+++ b/release.sh
@@ -76,7 +76,7 @@ compare_and_release() {
     git config --global user.name "Travis CI"
 
     git add CHANGELOG.md
-    git commit -v --edit -m "${NEXT} Release :tada: :fireworks: :bell:" -m "[skip ci]"
+    git commit -v -m "${NEXT} Release :tada: :fireworks: :bell:" -m "[skip ci]"
 
     git remote rm origin
     # Add new "origin" with access token in the git URL for authentication

--- a/test/unit/service/execution.test.ts
+++ b/test/unit/service/execution.test.ts
@@ -46,8 +46,8 @@ describe('SERVICE: execution', () => {
         execution: 'parallel'
       } as Configuration);
 
-      expect(result).to.have.deep.members(['Task A', 'Task B', 'Task C', 'Task D']);
-      expect(tracker).to.have.deep.members(['Task C', 'Task D', 'Task A', 'Task B']);
+      expect(result).to.include.members(['Task A', 'Task B', 'Task C', 'Task D']);
+      expect(tracker).to.include.members(['Task C', 'Task D', 'Task A', 'Task B']);
     });
 
     it('should throw an error if unknown strategy is provided.', () => {

--- a/test/unit/service/execution.test.ts
+++ b/test/unit/service/execution.test.ts
@@ -46,8 +46,8 @@ describe('SERVICE: execution', () => {
         execution: 'parallel'
       } as Configuration);
 
-      expect(result).to.deep.equal(['Task A', 'Task B', 'Task C', 'Task D']);
-      expect(tracker).to.deep.equal(['Task C', 'Task D', 'Task A', 'Task B']);
+      expect(result).to.have.deep.members(['Task A', 'Task B', 'Task C', 'Task D']);
+      expect(tracker).to.have.deep.members(['Task C', 'Task D', 'Task A', 'Task B']);
     });
 
     it('should throw an error if unknown strategy is provided.', () => {


### PR DESCRIPTION
Fix parallel strategy test case. 

https://stackoverflow.com/questions/44335770/node-mocha-chai-unit-tests-compare-array-of-objects-regardless-of-order

```
      [
      -  "Task A"
         "Task C"
         "Task D"
      +  "Task A"
         "Task B"
       ]
```

Fix release.sh script that was waiting for next task.
```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
The build has been terminated
```