### PR TITLE
Move ts-node to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "knex": "^0.20.11",
     "ramda": "^0.26.1",
     "tslib": "^1",
+    "ts-node": "^8",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
@@ -87,7 +88,6 @@
     "mocha": "^7",
     "nyc": "^15.0.0",
     "prettier": "2.0.2",
-    "ts-node": "^8",
     "tslint": "^6.1.3",
     "tslint-config-leapfrog": "^1.0.3",
     "typescript": "^3.8.2"


### PR DESCRIPTION
* `ts-node` should be a dependency because running `TypeScript` migrations depends on it