### PR TITLE
Throw an exception to rollback transaction if SQL migration fails

### DIFF
--- a/examples/node-mssql-programmatic-use/connections.sync-db.json.example
+++ b/examples/node-mssql-programmatic-use/connections.sync-db.json.example
@@ -4,11 +4,11 @@
       "id": "db1",
       "client": "mssql",
       "connection": {
-        "host": "localhost",
+        "host": "db",
         "port": 1433,
         "user": "sa",
         "database": "tempdb",
-        "password": "Password@123"
+        "password": "Secret@123"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -64,8 +64,8 @@
     "globby": "^10.0.2",
     "knex": "^0.20.11",
     "ramda": "^0.26.1",
-    "tslib": "^1",
     "ts-node": "^8",
+    "tslib": "^1",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/src/migration/KnexMigrationSource.ts
+++ b/src/migration/KnexMigrationSource.ts
@@ -41,8 +41,6 @@ class KnexMigrationSource {
    * @returns {string}
    */
   getMigrationName(migration: string): string {
-    this.log('getMigrationName - resolve: ', migration);
-
     return migration;
   }
 

--- a/src/service/execution.ts
+++ b/src/service/execution.ts
@@ -77,7 +77,7 @@ export async function executeOperation<T extends OperationContext>(
   if (result.error) {
     logDb('Result:\n%O', result);
 
-    throw result.error
+    throw result.error;
   }
 
   return result;

--- a/src/service/execution.ts
+++ b/src/service/execution.ts
@@ -59,7 +59,8 @@ export async function executeOperation<T extends OperationContext>(
 
     result.success = true;
   } catch (e) {
-    logDb(`Error caught for connection ${connectionId}:`, e);
+    logDb(`Error caught for connection ${connectionId}:`);
+
     result.error = e;
   }
 
@@ -77,7 +78,7 @@ export async function executeOperation<T extends OperationContext>(
   if (result.error) {
     logDb('Result:\n%O', result);
 
-    throw result.error;
+    throw { result };
   }
 
   return result;

--- a/src/service/execution.ts
+++ b/src/service/execution.ts
@@ -74,5 +74,11 @@ export async function executeOperation<T extends OperationContext>(
     await context.params.onFailed(result);
   }
 
+  if (result.error) {
+    logDb('Result:\n%O', result);
+
+    throw result.error
+  }
+
   return result;
 }

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -26,10 +26,10 @@ export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]>
       result.push(value);
     } catch (err) {
       if (!err.result) {
-        throw err
+        throw err;
       }
 
-      result.push(err.result)
+      result.push(err.result);
     }
   }
 

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -25,7 +25,11 @@ export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]>
 
       result.push(value);
     } catch (err) {
-      throw err;
+      if (!err.result) {
+        throw err
+      }
+
+      result.push(err.result)
     }
   }
 


### PR DESCRIPTION
Problem:

- `db.connection.transaction(async trx => { }` didn't rollback the transaction because no exception was thrown in SQL migration process. In case of migration and rollback `trx.migrate` and `trx.rollback` transaction rollback is handled internally.

- I've to remove the log from `getMigrationName` because it called more than a time which pollutes the console for a large number of migration files.