### PR TITLE
Fix verbose error when corruption in migration files

### DIFF
--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -113,7 +113,7 @@ class Synchronize extends Command {
 
       for (const attempt of failedAttempts) {
         await printLine(bold(` ▸ ${attempt.connectionId}\n`));
-        await printError(attempt.error.toString());
+        await printError(attempt.error.result.error);
 
         // Send verbose error with stack trace to debug logs.
         log(attempt.error);
@@ -159,7 +159,7 @@ class Synchronize extends Command {
         // Display output.
         await printLine(
           `Synchronization complete for ${successfulCount} / ${totalCount} connection(s). ` +
-            `(${getElapsedTime(timeStart)}s)\n`
+          `(${getElapsedTime(timeStart)}s)\n`
         );
       }
 

--- a/src/commands/synchronize.ts
+++ b/src/commands/synchronize.ts
@@ -159,7 +159,7 @@ class Synchronize extends Command {
         // Display output.
         await printLine(
           `Synchronization complete for ${successfulCount} / ${totalCount} connection(s). ` +
-          `(${getElapsedTime(timeStart)}s)\n`
+            `(${getElapsedTime(timeStart)}s)\n`
         );
       }
 


### PR DESCRIPTION
## Description
- Shows verbose error when corruption in migration files 

Fixes #124 

## Screenshot 
![sync-error](https://user-images.githubusercontent.com/45384962/131474120-c01406bd-2f71-494d-8a5f-e88ea0b6a012.png)
