### PR TITLE
Remove redundant existDir check

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -52,7 +52,7 @@ export async function synchronize(
   const { knexMigrationConfig } = await init.prepare(config, {
     migrationPath,
     loadSqlSources: true,
-    loadMigrations: !params['skip-migration'] || dirExist
+    loadMigrations: !params['skip-migration']
   });
 
   const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);


### PR DESCRIPTION
## Change

- The condition for `prepare` in synchonize api for loading migration wouldn't work correctly if skip-migration is set when dir exists 

## Fix

- Remove redundant addition of dirExists check