### PR TITLE
Send migration path before command execution

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -134,7 +134,10 @@ export async function migrateLatest(
   log('Migrate Latest');
 
   const params: OperationParams = { ...options };
-  const { knexMigrationConfig } = await init.prepare(config, { loadMigrations: true });
+  const { knexMigrationConfig } = await init.prepare(config, {
+    loadMigrations: true,
+    migrationPath: getMigrationPath(config)
+  });
 
   const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);
   const processes = connections.map(connection => () =>
@@ -170,7 +173,10 @@ export async function migrateRollback(
   log('Migrate Rollback');
 
   const params: OperationParams = { ...options };
-  const { knexMigrationConfig } = await init.prepare(config, { loadMigrations: true });
+  const { knexMigrationConfig } = await init.prepare(config, {
+    loadMigrations: true,
+    migrationPath: getMigrationPath(config)
+  });
 
   const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);
   const processes = connections.map(connection => () =>
@@ -206,7 +212,10 @@ export async function migrateList(
   log('Migrate List');
 
   const params: OperationParams = { ...options };
-  const { knexMigrationConfig } = await init.prepare(config, { loadMigrations: true });
+  const { knexMigrationConfig } = await init.prepare(config, {
+    loadMigrations: true,
+    migrationPath: getMigrationPath(config)
+  });
 
   const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);
   const processes = connections.map(connection => () =>

--- a/src/commands/migrate-latest.ts
+++ b/src/commands/migrate-latest.ts
@@ -77,6 +77,7 @@ class MigrateLatest extends Command {
     const { flags: parsedFlags } = this.parse(MigrateLatest);
     const isDryRun = parsedFlags['dry-run'];
     const config = await loadConfig(parsedFlags.config);
+
     const connections = await resolveConnections(config, parsedFlags['connection-resolver']);
 
     if (isDryRun) await printLine(magenta('\n• DRY RUN STARTED\n'));


### PR DESCRIPTION
While running the migration commands, it kept failing. The reason was because the `prepare` function didn't know about the migration path. A quick fix has been applied to each function in `api.ts` which makes the prepare function aware of the migration path.

**Before:**

```
migrate-list

 ▸ db1 - Failed
   Error: ENOENT: no such file or directory, scandir '/Users/saugat/Code/laudio/db/insights/migrations'

    TransactionError: Can't rollback transaction. There is a request in progress.
    Code: EREQINPROG
error Command failed with exit code 1.

---

migrate

 ▸ db1
   [✓] Rollback - started
   [✖] Rollback - failed (0s)

    TransactionError: Can't rollback transaction. There is a request in progress.
    Code: EREQINPROG
error Command failed with exit code 1.
```

**After:**

```
migrate

 ▸ db1
   [✓] Synchronization - started
   [✓] Synchronization - pruned (0s)
   [✓] Migrations - up to date (0.11s)
   [✓] Synchronization - completed (0.28s)
```