### PR TITLE
Fail synchronization if any error occurs while running sql scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.2.0",
+  "version": "1.1.1",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,7 +119,7 @@ export async function resolveConnections(config: Configuration, resolver?: strin
   } else if (resolver || config.connectionResolver) {
     connections = await resolveConnectionsUsingResolver(resolver || config.connectionResolver, config);
   } else {
-    log('Connections file not provided. Trying to load connection details from env.');
+    log('Connections file not provided. Loading connection details from env.');
 
     connections = resolveConnectionsFromEnv();
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,7 +119,7 @@ export async function resolveConnections(config: Configuration, resolver?: strin
   } else if (resolver || config.connectionResolver) {
     connections = await resolveConnectionsUsingResolver(resolver || config.connectionResolver, config);
   } else {
-    log('Connections file not provided.');
+    log('Connections file not provided. Trying to load connection details from env.');
 
     connections = resolveConnectionsFromEnv();
   }

--- a/src/service/sync.ts
+++ b/src/service/sync.ts
@@ -41,7 +41,7 @@ async function setup(trx: Knex.Transaction, context: SynchronizeContext): Promis
     log('PRE-SYNC: End');
   }
 
-  // Run the synchronization scripts.
+  // Run the synchronization scripts for database objects such as views, functions, procedures, etc.
   await sqlRunner.runSequentially(trx, sqlScripts, connectionId);
 
   if (postMigrationScripts.length > 0) {

--- a/src/service/sync.ts
+++ b/src/service/sync.ts
@@ -41,7 +41,7 @@ async function setup(trx: Knex.Transaction, context: SynchronizeContext): Promis
     log('PRE-SYNC: End');
   }
 
-  // Run the migration scripts.
+  // Run the synchronization scripts.
   await sqlRunner.runSequentially(trx, sqlScripts, connectionId);
 
   if (postMigrationScripts.length > 0) {

--- a/src/service/sync.ts
+++ b/src/service/sync.ts
@@ -41,7 +41,7 @@ async function setup(trx: Knex.Transaction, context: SynchronizeContext): Promis
     log('PRE-SYNC: End');
   }
 
-  // Run the synchronization scripts for database objects such as views, functions, procedures, etc.
+  // Run the synchronization scripts.
   await sqlRunner.runSequentially(trx, sqlScripts, connectionId);
 
   if (postMigrationScripts.length > 0) {

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -1,6 +1,5 @@
 import { promisify } from 'util';
-import isNil from 'ramda/src/isNil';
-import flatten from 'ramda/src/flatten';
+import { flatten, isNil } from 'ramda';
 
 /**
  * Promiser - A function that returns a promise.
@@ -20,6 +19,7 @@ export const timeout = promisify(setTimeout);
  */
 export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]> {
   const result: T[] = [];
+  const errors = [];
 
   for (const promiser of promisers) {
     try {
@@ -27,18 +27,20 @@ export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]>
 
       result.push(value);
     } catch (err) {
-      const errors = err as any;
+      const error = err as any;
 
-      if (errors.error) {
-        result.push(errors.error);
+      if (error.error) {
+        errors.push(error.error);
       }
 
-      if (errors.originalError) {
-        result.push(errors.originalError);
+      if (error.originalError) {
+        errors.push(error.originalError);
       }
 
-      result.push(errors);
-      throw flatten(result.filter(r => !isNil(r)));
+      errors.push(error);
+      const errorsWithData = flatten(errors.filter(r => !isNil(r)));
+
+      throw errorsWithData;
     }
   }
 

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -1,5 +1,4 @@
 import { promisify } from 'util';
-import { flatten, isNil } from 'ramda';
 
 /**
  * Promiser - A function that returns a promise.
@@ -19,7 +18,6 @@ export const timeout = promisify(setTimeout);
  */
 export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]> {
   const result: T[] = [];
-  const errors = [];
 
   for (const promiser of promisers) {
     try {
@@ -30,17 +28,14 @@ export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]>
       const error = err as any;
 
       if (error.error) {
-        errors.push(error.error);
+        throw error.error;
       }
 
       if (error.originalError) {
-        errors.push(error.originalError);
+        throw error.originalError
       }
 
-      errors.push(error);
-      const errorsWithData = flatten(errors.filter(r => !isNil(r)));
-
-      throw errorsWithData;
+      throw error;
     }
   }
 

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -1,4 +1,6 @@
 import { promisify } from 'util';
+import isNil from 'ramda/src/isNil';
+import flatten from 'ramda/src/flatten';
 
 /**
  * Promiser - A function that returns a promise.
@@ -27,13 +29,16 @@ export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]>
     } catch (err) {
       const errors = err as any;
 
+      if (errors.error) {
+        result.push(errors.error);
+      }
+
       if (errors.originalError) {
         result.push(errors.originalError);
-      } else if (errors.error) {
-        result.push(errors.error);
-      } else {
-        throw err;
       }
+
+      result.push(errors);
+      throw flatten(result.filter(r => !isNil(r)));
     }
   }
 

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -32,7 +32,7 @@ export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]>
       }
 
       if (error.originalError) {
-        throw error.originalError
+        throw error.originalError;
       }
 
       throw error;


### PR DESCRIPTION
**Problem**
While syncing database objects like views, and functions with sync-db, if there were any problems with the query files, then sync-db would not throw any errors but rather complete successfully and the database objects would not be created. That would lead us to believe that the operation was successful because the problems won't be revealed to us.

**Change**
This change fixes the problem by throwing errors if there were any errors in the synchronization scripts.

**Before, even in the case of problems**
![image](https://user-images.githubusercontent.com/15796651/209310560-6716d67e-c3f1-4279-89f4-248847530eca.png)

**After**
![image](https://user-images.githubusercontent.com/15796651/209310657-e414d2c0-b46b-48db-be8b-d93efc31dd0a.png)

