### PR TITLE
Skip synchronization of a database object if .dropped is appended on its name

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ _See code: [src/commands/prune.ts](https://github.com/leapfrogtechnology/sync-db
 
 ## `sync-db synchronize`
 
-Synchronize all the configured database connections.
+Synchronize all the configured database connections. If `.dropped` is appended with an database object's name,
+then that object will only be dropped, and not synchronized.
 
 ```
 USAGE
@@ -279,7 +280,7 @@ basePath: /path/to/sql
 
 sql:
   - schema/<schema_name>.sql
-  - function/<schema_name>/<function_name>.sql
+  - function/<schema_name>/<function_name>.sql.dropped #While syncing this will only be dropped, not upped.
   - procedure/<schema_name>/<procedure_name>.sql
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.2.0",
+  "version": "1.1.1",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,3 +32,5 @@ export const DEFAULT_CONFIG: Configuration = {
 };
 
 export const REQUIRED_ENV_KEYS = ['DB_HOST', 'DB_PASSWORD', 'DB_NAME', 'DB_USERNAME', 'DB_PORT', 'DB_CLIENT'];
+
+export const DROP_ONLY_OBJECT_TERMINATOR = '.dropped';

--- a/src/domain/SqlCode.ts
+++ b/src/domain/SqlCode.ts
@@ -4,6 +4,7 @@
 interface SqlCode {
   sql: string;
   name: string;
+  dropOnly?: boolean;
 }
 
 export default SqlCode;

--- a/src/service/sqlRunner.ts
+++ b/src/service/sqlRunner.ts
@@ -90,9 +90,9 @@ export function extractSqlFileInfo(filePath: string): SqlFileInfo {
   const fileName = fileParts.pop() || '';
   const [type, schema] = fileParts;
 
-  // File name might contain `.dropped` at the end which we need to remove in case of dropping the database objects.
-  let name = fileName.replace(DROP_ONLY_OBJECT_TERMINATOR, '');
-  name = name.replace('.sql', '');
+  // Remove .sql and .dropped (if exists) from the file name.
+  const santizeFileNameRegex = /(.sql)|(.dropped)/g;
+  let name = fileName.replace(santizeFileNameRegex, '');
   const fqon = getFQON(type, name, schema);
 
   return { name, fqon, type, schema };

--- a/src/service/sqlRunner.ts
+++ b/src/service/sqlRunner.ts
@@ -92,7 +92,7 @@ export function extractSqlFileInfo(filePath: string): SqlFileInfo {
 
   // Remove .sql and .dropped (if exists) from the file name.
   const santizeFileNameRegex = /(.sql)|(.dropped)/g;
-  let name = fileName.replace(santizeFileNameRegex, '');
+  const name = fileName.replace(santizeFileNameRegex, '');
   const fqon = getFQON(type, name, schema);
 
   return { name, fqon, type, schema };

--- a/src/service/sqlRunner.ts
+++ b/src/service/sqlRunner.ts
@@ -8,6 +8,7 @@ import SqlCode from '../domain/SqlCode';
 import { dbLogger } from '../util/logger';
 import * as promise from '../util/promise';
 import SqlFileInfo from '../domain/SqlFileInfo';
+import { DROP_ONLY_OBJECT_TERMINATOR } from '../constants';
 import DatabaseObjectTypes from '../enum/DatabaseObjectTypes';
 
 /**
@@ -22,17 +23,26 @@ const dropStatementsMap: Mapping<string> = {
 };
 
 /**
- * Reads an sql file and return it's contents.
+ * Reads an sql file and return it's contents. If a file ends with `.dropped` on the config file,
+ * dropOnly is set as true, and that object would not be synchronized, only dropped.
  *
  * @param {string} sqlBasePath
  * @param {string} fileName
  * @returns {Promise<SqlCode>}
  */
 export async function resolveFile(sqlBasePath: string, fileName: string): Promise<SqlCode> {
-  const filePath = path.resolve(sqlBasePath, fileName);
+  let name = fileName;
+  let dropOnly = false;
+
+  if (fileName.includes(DROP_ONLY_OBJECT_TERMINATOR)) {
+    name = fileName.replace(DROP_ONLY_OBJECT_TERMINATOR, '');
+    dropOnly = true;
+  }
+
+  const filePath = path.resolve(sqlBasePath, name);
   const sql = await fs.read(filePath);
 
-  return { sql, name: fileName };
+  return { sql, name, dropOnly };
 }
 
 /**
@@ -65,7 +75,7 @@ export function getFQON(type: string, name: string, schema?: string): string {
 }
 
 /**
- * Extract sql file info from the filePath
+ * Extract sql file info from the filePath to rollback the synchronization.
  *
  * @param {string} filePath
  * @returns {SqlFileInfo}
@@ -79,7 +89,10 @@ export function extractSqlFileInfo(filePath: string): SqlFileInfo {
   const fileParts = filePath.split('/');
   const fileName = fileParts.pop() || '';
   const [type, schema] = fileParts;
-  const name = fileName.replace('.sql', '');
+
+  // File name might contain `.dropped` at the end which we need to remove in case of dropping the database objects.
+  let name = fileName.replace(DROP_ONLY_OBJECT_TERMINATOR, '');
+  name = name.replace('.sql', '');
   const fqon = getFQON(type, name, schema);
 
   return { name, fqon, type, schema };
@@ -115,6 +128,12 @@ export function getDropStatement(type: string, fqon: string): string {
 export function runSequentially(trx: Knex, files: SqlCode[], connectionId: string): Promise<any[]> {
   const log = dbLogger(connectionId);
   const promises = files.map(file => {
+    if (file.dropOnly) {
+      log(`Skipping ${file.name} from synchronization.`);
+
+      return () => Promise.resolve();
+    }
+
     log(`Running ${file.name}`);
 
     return () => trx.raw(file.sql);

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -32,7 +32,7 @@ export async function runSequentially<T>(promisers: Promiser<T>[]): Promise<T[]>
       }
 
       if (error.originalError) {
-        throw error.originalError
+        throw error.originalError;
       }
 
       throw error;

--- a/test/unit/migration/migrator.test.ts
+++ b/test/unit/migration/migrator.test.ts
@@ -70,7 +70,7 @@ describe('MIGRATION: migrator', () => {
         {
           name: '0001_mgr',
           queries: {
-            up: { name: '0001_mgr.up.sql', sql: 'CREATE TABLE test_mgr1' },
+            up: { name: '0001_mgr.up.sql', sql: 'CREATE TABLE test_mgr1', dropOnly: false },
             down: undefined
           }
         },
@@ -78,14 +78,14 @@ describe('MIGRATION: migrator', () => {
           name: '0002_mgr',
           queries: {
             up: undefined,
-            down: { name: '0002_mgr.down.sql', sql: 'DROP TABLE test_mgr2' }
+            down: { name: '0002_mgr.down.sql', sql: 'DROP TABLE test_mgr2', dropOnly: false }
           }
         },
         {
           name: '0003_mgr',
           queries: {
-            up: { name: '0003_mgr.up.sql', sql: 'CREATE TABLE test_mgr3' },
-            down: { name: '0003_mgr.down.sql', sql: 'DROP TABLE test_mgr3' }
+            up: { name: '0003_mgr.up.sql', sql: 'CREATE TABLE test_mgr3', dropOnly: false },
+            down: { name: '0003_mgr.down.sql', sql: 'DROP TABLE test_mgr3', dropOnly: false }
           }
         }
       ]);


### PR DESCRIPTION
**Problem**
The only way we have right now to remove an already synced database is to first remove the view manually, and then remove it from the config file and remove the actual file. 

**Change**
With this change, we can just append `.dropped` to any database object in the config file, and then sync-db will only drop the view/function/proc and not synchronize (up) it. We can remove that object from the config file immediately after synchronization or after some point in time. 