### PR TITLE
Rename `.dropped` to `.drop` & update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ _See code: [src/commands/prune.ts](https://github.com/leapfrogtechnology/sync-db
 
 ## `sync-db synchronize`
 
-Synchronize all the configured database connections. If `.dropped` is appended with an database object's name,
+Synchronize all the configured database connections. If `.drop` is appended with an database object's name,
 then that object will only be dropped, and not synchronized.
 
 ```
@@ -280,7 +280,7 @@ basePath: /path/to/sql
 
 sql:
   - schema/<schema_name>.sql
-  - function/<schema_name>/<function_name>.sql.dropped #While syncing this will only be dropped, not upped.
+  - function/<schema_name>/<function_name>.sql.drop #While syncing this will only be dropped, not synced.
   - procedure/<schema_name>/<procedure_name>.sql
 ```
 

--- a/examples/node-app-mssql-ts/src/sql/view/utils/vw_user_emails.sql
+++ b/examples/node-app-mssql-ts/src/sql/view/utils/vw_user_emails.sql
@@ -1,0 +1,9 @@
+--
+-- View to fetch the list of email addresses.
+-- This view is written to display the purpose of `.drop` terminator in the config file. Since, in the config file,
+-- `.drop` is appended to this database object's name, sync-db will only attempt to drop it and never attempt to sync it.
+--
+CREATE VIEW [utils].vw_user_emails
+AS (
+  SELECT id, email FROM users
+);

--- a/examples/node-app-mssql-ts/sync-db.yml
+++ b/examples/node-app-mssql-ts/sync-db.yml
@@ -12,7 +12,7 @@ sql:
   - procedure/utils/get_date.sql
   - view/utils/vw_users.sql
   - view/utils/vw_tasks.sql
-  - view/utils/vw_user_emails.sql.drop
+  - view/utils/vw_user_emails.sql.drop # This view will only be dropped - not synchronized.
 
   # Create objects in testdata schema
   - schema/testdata.sql

--- a/examples/node-app-mssql-ts/sync-db.yml
+++ b/examples/node-app-mssql-ts/sync-db.yml
@@ -12,6 +12,7 @@ sql:
   - procedure/utils/get_date.sql
   - view/utils/vw_users.sql
   - view/utils/vw_tasks.sql
+  - view/utils/vw_user_emails.sql.drop
 
   # Create objects in testdata schema
   - schema/testdata.sql

--- a/examples/node-app-mssql/src/sql/view/utils/vw_user_emails.sql
+++ b/examples/node-app-mssql/src/sql/view/utils/vw_user_emails.sql
@@ -1,0 +1,9 @@
+--
+-- View to fetch the list of email addresses.
+-- This view is written to display the purpose of `.drop` terminator in the config file. Since, in the config file,
+-- `.drop` is appended to this database object's name, sync-db will only attempt to drop it and never attempt to sync it.
+--
+CREATE VIEW [utils].vw_user_emails
+AS (
+  SELECT id, email FROM users
+);

--- a/examples/node-app-mssql/sync-db.yml
+++ b/examples/node-app-mssql/sync-db.yml
@@ -12,7 +12,7 @@ sql:
   - procedure/utils/get_date.sql
   - view/utils/vw_users.sql
   - view/utils/vw_tasks.sql
-  - view/utils/vw_user_emails.sql.drop
+  - view/utils/vw_user_emails.sql.drop # This view will only be dropped - not synchronized.
 
   # Create objects in testdata schema
   - schema/testdata.sql

--- a/examples/node-app-mssql/sync-db.yml
+++ b/examples/node-app-mssql/sync-db.yml
@@ -12,6 +12,7 @@ sql:
   - procedure/utils/get_date.sql
   - view/utils/vw_users.sql
   - view/utils/vw_tasks.sql
+  - view/utils/vw_user_emails.sql.drop
 
   # Create objects in testdata schema
   - schema/testdata.sql

--- a/examples/node-app-pg-ts/src/sql/view/utils/vw_current_queries.sql
+++ b/examples/node-app-pg-ts/src/sql/view/utils/vw_current_queries.sql
@@ -1,0 +1,9 @@
+--
+-- View to fetch the list of current queries executed by users who are connected to the database
+-- This view is written to display the purpose of `.drop` terminator in the config file. Since, in the config file,
+-- `.drop` is appended to this database object's name, sync-db will only attempt to drop it and never attempt to sync it.
+--
+CREATE VIEW utils.vw_current_queries
+AS (
+  SELECT datname, usename, query FROM pg_stat_activity;
+);

--- a/examples/node-app-pg-ts/src/sql/view/utils/vw_current_queries.sql
+++ b/examples/node-app-pg-ts/src/sql/view/utils/vw_current_queries.sql
@@ -5,5 +5,5 @@
 --
 CREATE VIEW utils.vw_current_queries
 AS (
-  SELECT datname, usename, query FROM pg_stat_activity;
+  SELECT datname, usename, query FROM pg_stat_activity
 );

--- a/examples/node-app-pg-ts/sync-db.yml
+++ b/examples/node-app-pg-ts/sync-db.yml
@@ -12,6 +12,7 @@ sql:
   - function/utils/get_date.sql
   - view/utils/vw_table_names.sql
   - view/utils/vw_user_names.sql
+  - view/utils/vw_current_queries.sql.drop # This view will only be dropped - not synchronized.
 
 migration:
   directory: migrations

--- a/examples/node-app-pg/src/sql/view/utils/vw_current_queries.sql
+++ b/examples/node-app-pg/src/sql/view/utils/vw_current_queries.sql
@@ -1,0 +1,9 @@
+--
+-- View to fetch the list of current queries executed by users who are connected to the database
+-- This view is written to display the purpose of `.drop` terminator in the config file. Since, in the config file,
+-- `.drop` is appended to this database object's name, sync-db will only attempt to drop it and never attempt to sync it.
+--
+CREATE VIEW utils.vw_current_queries
+AS (
+  SELECT datname, usename, query FROM pg_stat_activity;
+);

--- a/examples/node-app-pg/src/sql/view/utils/vw_current_queries.sql
+++ b/examples/node-app-pg/src/sql/view/utils/vw_current_queries.sql
@@ -5,5 +5,5 @@
 --
 CREATE VIEW utils.vw_current_queries
 AS (
-  SELECT datname, usename, query FROM pg_stat_activity;
+  SELECT datname, usename, query FROM pg_stat_activity
 );

--- a/examples/node-app-pg/sync-db.yml
+++ b/examples/node-app-pg/sync-db.yml
@@ -12,6 +12,7 @@ sql:
   - function/utils/get_date.sql
   - view/utils/vw_table_names.sql
   - view/utils/vw_user_names.sql
+  - view/utils/vw_current_queries.sql.drop # This view will only be dropped - not synchronized.
 
 migration:
   directory: migrations

--- a/examples/node-mssql-programmatic-use/src/sql/view/utils/vw_principals.sql
+++ b/examples/node-mssql-programmatic-use/src/sql/view/utils/vw_principals.sql
@@ -1,0 +1,10 @@
+--
+-- View to fetch the list of server-level principals.
+-- This view is written to display the purpose of `.drop` terminator in the config file. Since, in the config file,
+-- `.drop` is appended to this database object's name, sync-db will only attempt to drop it and never attempt to sync it.
+--
+CREATE VIEW [utils].vw_principals
+AS (
+  SELECT name, principal_id
+  FROM sys.server_principals
+);

--- a/examples/node-mssql-programmatic-use/sync-db.yml
+++ b/examples/node-mssql-programmatic-use/sync-db.yml
@@ -12,6 +12,7 @@ sql:
   - procedure/utils/get_date.sql
   - view/utils/vw_table_names.sql
   - view/utils/vw_user_names.sql
+  - view/utils/vw_principals.sql.drop # This view will only be dropped - not synchronized.
 
 migration:
   sourceType: javascript

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,4 +33,4 @@ export const DEFAULT_CONFIG: Configuration = {
 
 export const REQUIRED_ENV_KEYS = ['DB_HOST', 'DB_PASSWORD', 'DB_NAME', 'DB_USERNAME', 'DB_PORT', 'DB_CLIENT'];
 
-export const DROP_ONLY_OBJECT_TERMINATOR = '.dropped';
+export const DROP_ONLY_OBJECT_TERMINATOR = '.drop';

--- a/src/service/sqlRunner.ts
+++ b/src/service/sqlRunner.ts
@@ -23,7 +23,7 @@ const dropStatementsMap: Mapping<string> = {
 };
 
 /**
- * Reads an sql file and return it's contents. If a file ends with `.dropped` on the config file,
+ * Reads an sql file and return it's contents. If a file ends with `.drop` on the config file,
  * dropOnly is set as true, and that object would not be synchronized, only dropped.
  *
  * @param {string} sqlBasePath
@@ -90,8 +90,8 @@ export function extractSqlFileInfo(filePath: string): SqlFileInfo {
   const fileName = fileParts.pop() || '';
   const [type, schema] = fileParts;
 
-  // Remove .sql and .dropped (if exists) from the file name.
-  const santizeFileNameRegex = /(.sql)|(.dropped)/g;
+  // Remove .sql and .drop (if exists) from the file name.
+  const santizeFileNameRegex = /(.sql)|(.drop)/g;
   const name = fileName.replace(santizeFileNameRegex, '');
   const fqon = getFQON(type, name, schema);
 


### PR DESCRIPTION
- Rename the occurrences of `.dropped` to `.drop`
- Update examples to include the usage of `.drop`
- Update version