### PR TITLE
Remove error log when dir does not exist (v2.0.1 Release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/api.ts
+++ b/src/api.ts
@@ -40,6 +40,10 @@ export async function synchronize(
   const migrationPath = getMigrationPath(config);
   const dirExist = await existsDir(migrationPath);
 
+  if (!dirExist) {
+    log('Migration directory does not exist');
+  }
+
   const params: SynchronizeParams = {
     force: false,
     'skip-migration': !dirExist,

--- a/src/commands/migrate-list.ts
+++ b/src/commands/migrate-list.ts
@@ -36,7 +36,9 @@ class MigrateList extends Command {
 
     // Completed migrations.
     for (const item of completedList) {
-      await printLine(cyan(`   • ${item}`));
+      const completedMigrationName = typeof item === 'string' || item instanceof String ? item : item?.name;
+
+      await printLine(cyan(`   • ${completedMigrationName}`));
     }
 
     // Remaining Migrations

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { log } from './logger';
 import { promisify } from 'util';
 
 export const mkdir = promisify(fs.mkdir);
@@ -66,8 +65,6 @@ export async function existsDir(pathName: string) {
 
     return true;
   } catch (err) {
-    log(err);
-
     return false;
   }
 }


### PR DESCRIPTION
- Just to avoid confusion, sometimes the migration directory does not need to exist for sync db to run. In those cases, we don't need to log an error