### PR TITLE
Fix the type displayed instead of migration name with migrate-list

### DIFF
--- a/src/commands/migrate-list.ts
+++ b/src/commands/migrate-list.ts
@@ -36,7 +36,9 @@ class MigrateList extends Command {
 
     // Completed migrations.
     for (const item of completedList) {
-      await printLine(cyan(`   • ${item}`));
+      const completedMigrationName = typeof item === 'string' || item instanceof String ? item : item?.name;
+
+      await printLine(cyan(`   • ${completedMigrationName}`));
     }
 
     // Remaining Migrations


### PR DESCRIPTION
## Changes
![image](https://github.com/leapfrogtechnology/sync-db/assets/35683880/ed3d9a94-6ee9-4273-8f11-a9f4a9c0fb78)

- The result of running the migration list returns data as above now. Previously, it used to be just the array of names
- I am not sure about the cause, but don't see any related changes in recent commits

## After fix

![image](https://github.com/leapfrogtechnology/sync-db/assets/35683880/9a5d05af-9d49-4029-b1c5-2f78272e891d)

Fixes https://github.com/leapfrogtechnology/sync-db/issues/204
