### PR TITLE
Update --only flag to support multiple connection filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ OPTIONS
   -c, --config=config         Custom configuration file.
   --connection-resolver=PATH  Path to the connection resolver.
   --dry-run                   Dry run migration.
-  --only=CONNECTION_ID        Filter provided connection(s).
+  --only=CONNECTION_ID(s)     Filter provided connection(s). Comma separated ids eg: id1,id2
 ```
 
 _See code: [src/commands/migrate-latest.ts](https://github.com/leapfrogtechnology/sync-db/blob/v2.0.1/src/commands/migrate-latest.ts)_
@@ -159,7 +159,7 @@ USAGE
 OPTIONS
   -c, --config=config         Custom configuration file.
   --connection-resolver=PATH  Path to the connection resolver.
-  --only=CONNECTION_ID        Filter provided connection(s).
+  --only=CONNECTION_ID(s)     Filter provided connection(s). Comma separated ids eg: id1,id2
 ```
 
 _See code: [src/commands/migrate-list.ts](https://github.com/leapfrogtechnology/sync-db/blob/v2.0.1/src/commands/migrate-list.ts)_
@@ -176,7 +176,7 @@ OPTIONS
   -c, --config=config         Custom configuration file.
   --connection-resolver=PATH  Path to the connection resolver.
   --dry-run                   Dry run rollback.
-  --only=CONNECTION_ID        Filter provided connection(s).
+  --only=CONNECTION_ID(s)     Filter provided connection(s). Comma separated ids eg: id1,id2
 ```
 
 _See code: [src/commands/migrate-rollback.ts](https://github.com/leapfrogtechnology/sync-db/blob/v2.0.1/src/commands/migrate-rollback.ts)_
@@ -193,7 +193,7 @@ OPTIONS
   -c, --config=config         Custom configuration file.
   --connection-resolver=PATH  Path to the connection resolver.
   --dry-run                   Dry run prune.
-  --only=CONNECTION_ID        Filter provided connection(s).
+  --only=CONNECTION_ID(s)     Filter provided connection(s). Comma separated ids eg: id1,id2
 ```
 
 _See code: [src/commands/prune.ts](https://github.com/leapfrogtechnology/sync-db/blob/v2.0.1/src/commands/prune.ts)_
@@ -211,7 +211,7 @@ OPTIONS
   -f, --force                 Force synchronization.
   --connection-resolver=PATH  Path to the connection resolver.
   --dry-run                   Dry run synchronization.
-  --only=CONNECTION_ID        Filter provided connection(s).
+  --only=CONNECTION_ID(s)     Filter provided connection(s). Comma separated ids eg: id1,id2
   --skip-migration            Skip running migrations.
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ OPTIONS
   -c, --config=config         Custom configuration file.
   --connection-resolver=PATH  Path to the connection resolver.
   --dry-run                   Dry run migration.
-  --only=CONNECTION_ID        Filter only a single connection.
+  --only=CONNECTION_ID        Filter provided connection(s).
 ```
 
 _See code: [src/commands/migrate-latest.ts](https://github.com/leapfrogtechnology/sync-db/blob/v2.0.1/src/commands/migrate-latest.ts)_
@@ -159,7 +159,7 @@ USAGE
 OPTIONS
   -c, --config=config         Custom configuration file.
   --connection-resolver=PATH  Path to the connection resolver.
-  --only=CONNECTION_ID        Filter only a single connection.
+  --only=CONNECTION_ID        Filter provided connection(s).
 ```
 
 _See code: [src/commands/migrate-list.ts](https://github.com/leapfrogtechnology/sync-db/blob/v2.0.1/src/commands/migrate-list.ts)_
@@ -176,7 +176,7 @@ OPTIONS
   -c, --config=config         Custom configuration file.
   --connection-resolver=PATH  Path to the connection resolver.
   --dry-run                   Dry run rollback.
-  --only=CONNECTION_ID        Filter only a single connection.
+  --only=CONNECTION_ID        Filter provided connection(s).
 ```
 
 _See code: [src/commands/migrate-rollback.ts](https://github.com/leapfrogtechnology/sync-db/blob/v2.0.1/src/commands/migrate-rollback.ts)_
@@ -193,7 +193,7 @@ OPTIONS
   -c, --config=config         Custom configuration file.
   --connection-resolver=PATH  Path to the connection resolver.
   --dry-run                   Dry run prune.
-  --only=CONNECTION_ID        Filter only a single connection.
+  --only=CONNECTION_ID        Filter provided connection(s).
 ```
 
 _See code: [src/commands/prune.ts](https://github.com/leapfrogtechnology/sync-db/blob/v2.0.1/src/commands/prune.ts)_
@@ -211,7 +211,7 @@ OPTIONS
   -f, --force                 Force synchronization.
   --connection-resolver=PATH  Path to the connection resolver.
   --dry-run                   Dry run synchronization.
-  --only=CONNECTION_ID        Filter only a single connection.
+  --only=CONNECTION_ID        Filter provided connection(s).
   --skip-migration            Skip running migrations.
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapfrogtechnology/sync-db",
   "description": "Command line utility to synchronize and version control relational database objects across databases",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/api.ts
+++ b/src/api.ts
@@ -247,7 +247,7 @@ function filterConnectionsAsRequired(
   connections: ConnectionReference[],
   filterConnectionIds?: string
 ): ConnectionReference[] {
-  const trimmedFilterConnectionIds = filterConnectionIds?.split(',').map(id => id.trim());
+  const trimmedFilterConnectionIds = Array.from(new Set(filterConnectionIds?.split(',').map(id => id.trim())));
   const formattedFilterConnectionIds = trimmedFilterConnectionIds?.join(', ');
 
   log(`Filter(s) (--only=) ${formattedFilterConnectionIds}`);
@@ -261,12 +261,17 @@ function filterConnectionsAsRequired(
 
   const filteredList = connections.filter(connection => trimmedFilterConnectionIds?.includes(connection.id));
 
-  if (filteredList.length === 0) {
-    const available = connections.map(({ id }) => id);
+  const available = connections.map(({ id }) => id);
+  const invalidIds = trimmedFilterConnectionIds.filter(tids => !available.includes(tids));
 
+  if (filteredList.length === 0) {
     throw new Error(
       `No connections found for given id(s) "${formattedFilterConnectionIds}. Available ids are: ${available}`
     );
+  }
+
+  if (invalidIds.length) {
+    log(`No connections found for given id(s) "${invalidIds.join(', ')}. Available ids are: ${available}`);
   }
 
   const filteredConnectionIds = filteredList.map(({ id }) => id).join(', ');

--- a/src/api.ts
+++ b/src/api.ts
@@ -59,7 +59,7 @@ export async function synchronize(
     loadMigrations: !params['skip-migration']
   });
 
-  const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);
+  const connections = filterConnections(mapToConnectionReferences(conn), params.only);
   const processes = connections.map(connection => () =>
     withTransaction(
       connection,
@@ -105,7 +105,7 @@ export async function prune(
   // TODO: Need to preload the SQL source code under this step.
   await init.prepare(config, { loadSqlSources: true });
 
-  const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);
+  const connections = filterConnections(mapToConnectionReferences(conn), params.only);
   const processes = connections.map(connection => () =>
     withTransaction(
       connection,
@@ -143,7 +143,7 @@ export async function migrateLatest(
     migrationPath: getMigrationPath(config)
   });
 
-  const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);
+  const connections = filterConnections(mapToConnectionReferences(conn), params.only);
   const processes = connections.map(connection => () =>
     withTransaction(
       connection,
@@ -182,7 +182,7 @@ export async function migrateRollback(
     migrationPath: getMigrationPath(config)
   });
 
-  const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);
+  const connections = filterConnections(mapToConnectionReferences(conn), params.only);
   const processes = connections.map(connection => () =>
     withTransaction(
       connection,
@@ -221,7 +221,7 @@ export async function migrateList(
     migrationPath: getMigrationPath(config)
   });
 
-  const connections = filterConnectionsAsRequired(mapToConnectionReferences(conn), params.only);
+  const connections = filterConnections(mapToConnectionReferences(conn), params.only);
   const processes = connections.map(connection => () =>
     withTransaction(connection, trx =>
       invokeMigrationApi(trx, KnexMigrationAPI.MIGRATE_LIST, {
@@ -243,10 +243,7 @@ export async function migrateList(
  * @param {string} [connectionIds]
  * @returns {ConnectionReference[]}
  */
-function filterConnectionsAsRequired(
-  connections: ConnectionReference[],
-  connectionIds?: string
-): ConnectionReference[] {
+function filterConnections(connections: ConnectionReference[], connectionIds?: string): ConnectionReference[] {
   const trimmedFilterConnectionIds = Array.from(new Set(connectionIds?.split(',').map(id => id.trim())));
 
   log(`Filter(s) (--only=) ${trimmedFilterConnectionIds}`);

--- a/src/api.ts
+++ b/src/api.ts
@@ -240,19 +240,19 @@ export async function migrateList(
  * Check the filter condition and apply filter if required.
  *
  * @param {ConnectionReference[]} connections
- * @param {string} [filterConnectionIds]
+ * @param {string} [connectionIds]
  * @returns {ConnectionReference[]}
  */
 function filterConnectionsAsRequired(
   connections: ConnectionReference[],
-  filterConnectionIds?: string
+  connectionIds?: string
 ): ConnectionReference[] {
-  const trimmedFilterConnectionIds = Array.from(new Set(filterConnectionIds?.split(',').map(id => id.trim())));
+  const trimmedFilterConnectionIds = Array.from(new Set(connectionIds?.split(',').map(id => id.trim())));
 
   log(`Filter(s) (--only=) ${trimmedFilterConnectionIds}`);
 
   // Apply no filter if the connection id is not provided.
-  if (!filterConnectionIds) {
+  if (!connectionIds) {
     log('Running for all connections.');
 
     return connections;

--- a/src/api.ts
+++ b/src/api.ts
@@ -240,31 +240,38 @@ export async function migrateList(
  * Check the filter condition and apply filter if required.
  *
  * @param {ConnectionReference[]} connections
- * @param {string} [filterConnectionId]
+ * @param {string} [filterConnectionIds]
  * @returns {ConnectionReference[]}
  */
 function filterConnectionsAsRequired(
   connections: ConnectionReference[],
-  filterConnectionId?: string
+  filterConnectionIds?: string
 ): ConnectionReference[] {
-  log(`Filter (--only=) ${filterConnectionId}`);
+  const trimmedFilterConnectionIds = filterConnectionIds?.split(',').map(id => id.trim());
+  const formattedFilterConnectionIds = trimmedFilterConnectionIds?.join(', ');
+
+  log(`Filter(s) (--only=) ${formattedFilterConnectionIds}`);
 
   // Apply no filter if the connection id is not provided.
-  if (!filterConnectionId) {
+  if (!filterConnectionIds) {
     log('Running for all connections.');
 
     return connections;
   }
 
-  const filteredList = connections.filter(connection => connection.id === filterConnectionId);
+  const filteredList = connections.filter(connection => trimmedFilterConnectionIds?.includes(connection.id));
 
   if (filteredList.length === 0) {
     const available = connections.map(({ id }) => id);
 
-    throw new Error(`No connections found for given id "${filterConnectionId}. Available ids are: ${available}`);
+    throw new Error(
+      `No connections found for given id(s) "${formattedFilterConnectionIds}. Available ids are: ${available}`
+    );
   }
 
-  log(`Running for a single connection (id = ${filterConnectionId}).`);
+  const filteredConnectionIds = filteredList.map(({ id }) => id).join(', ');
+
+  log(`Running for a filtered connection(s) (id(s) = ${filteredConnectionIds}).`);
 
   return filteredList;
 }


### PR DESCRIPTION
## Context

- For multiple connection provided to sync-db, it was difficult to filter a subset of connection for which we require to synchronize the migrations. `--only` flag supported only a single connectionId which is a bit hectic

## Changes

- Update `--only` to support multiple `,` separated connection identifiers
- Any unwanted connection ids also get filtered if provided

## Test and Demo

### connections.sync-db.json
```
{
  "connections": [
    {
      "id": "db1",
      "client": "mssql",
      "connection": {
        "host": "mssql",
        "port": 1433,
        "user": "sa",
        "database": "tempdb",
        "password": "Secret@123"
      }
    },
    {
      "id": "db2",
      "client": "mssql",
      "connection": {
        "host": "mssql",
        "port": 1433,
        "user": "sa",
        "database": "tempdb1",
        "password": "Secret@123"
      }
    },
    {
      "id": "db3",
      "client": "mssql",
      "connection": {
        "host": "mssql",
        "port": 1433,
        "user": "sa",
        "database": "tempdb2",
        "password": "Secret@123"
      }
    },
    {
      "id": "db4",
      "client": "mssql",
      "connection": {
        "host": "mssql",
        "port": 1433,
        "user": "sa",
        "database": "tempdb3",
        "password": "Secret@123"
      }
    }
  ]
}

```

![image](https://github.com/leapfrogtechnology/sync-db/assets/35683880/aafb1f2d-73db-4103-a6f8-bdaa25a267c4)

![image](https://github.com/leapfrogtechnology/sync-db/assets/35683880/1a37da8d-9a49-405d-9649-3bb7866162e9)

