### PR TITLE
Introduce new command to run manual scripts

### DIFF
--- a/src/commands/run-script.ts
+++ b/src/commands/run-script.ts
@@ -4,6 +4,7 @@ import { bold, red, magenta, cyan } from 'chalk';
 import { runScriptAPI } from '../api';
 import { dbLogger } from '../util/logger';
 import { loadConfig, resolveConnections } from '..';
+import { validateScriptFileName } from '../util/fs';
 import { printLine, printError, printInfo } from '../util/io';
 import OperationResult from '../domain/operation/OperationResult';
 
@@ -17,7 +18,9 @@ class RunScript extends Command {
       description: 'Filter provided connection(s). Comma separated ids eg: id1,id2'
     }),
     file: flags.string({
+      required: true,
       helpValue: 'Script Name',
+      parse: validateScriptFileName,
       description: 'Name of the manual SQL/JS/TS script'
     }),
     'connection-resolver': flags.string({

--- a/src/commands/run-script.ts
+++ b/src/commands/run-script.ts
@@ -17,8 +17,8 @@ class RunScript extends Command {
       description: 'Filter provided connection(s). Comma separated ids eg: id1,id2'
     }),
     file: flags.string({
-      helpValue: 'PATH',
-      description: 'Path to the manual SQL/JS/TS script'
+      helpValue: 'Script Name',
+      description: 'Name of the manual SQL/JS/TS script'
     }),
     'connection-resolver': flags.string({
       helpValue: 'PATH',
@@ -101,7 +101,7 @@ class RunScript extends Command {
       return process.exit(0);
     }
 
-    printError(`Error: Migration failed for ${failedCount} connection(s).`);
+    printError(`Error: Script failed for ${failedCount} connection(s).`);
 
     if (isDryRun) await printLine(magenta('\n• DRY RUN ENDED\n'));
 

--- a/src/commands/run-script.ts
+++ b/src/commands/run-script.ts
@@ -1,0 +1,112 @@
+import { Command, flags } from '@oclif/command';
+import { bold, red, magenta, cyan } from 'chalk';
+
+import { runScriptAPI } from '../api';
+import { dbLogger } from '../util/logger';
+import { loadConfig, resolveConnections } from '..';
+import { printLine, printError, printInfo } from '../util/io';
+import OperationResult from '../domain/operation/OperationResult';
+
+class RunScript extends Command {
+  static description = 'Run the migrations up to the latest changes.';
+
+  static flags = {
+    'dry-run': flags.boolean({ description: 'Dry run migration.', default: false }),
+    only: flags.string({
+      helpValue: 'CONNECTION_ID(s)',
+      description: 'Filter provided connection(s). Comma separated ids eg: id1,id2'
+    }),
+    file: flags.string({
+      helpValue: 'PATH',
+      description: 'Path to the manual SQL query'
+    }),
+    'connection-resolver': flags.string({
+      helpValue: 'PATH',
+      description: 'Path to the connection resolver.'
+    }),
+    config: flags.string({
+      char: 'c',
+      description: 'Custom configuration file.'
+    })
+  };
+
+  /**
+   * Started event handler.
+   */
+  onStarted = async (result: OperationResult) => {
+    await printLine(bold(` ▸ ${result.connectionId}`));
+
+    await printInfo('   [✓] Manual script run - started');
+  };
+
+  /**
+   * Success handler.
+   */
+  onSuccess = async (result: OperationResult) => {
+    const log = dbLogger(result.connectionId);
+    const [num, list] = result.data;
+    const alreadyUpToDate = num && list.length === 0;
+
+    log('Up to date: ', alreadyUpToDate);
+
+    await printInfo(`   [✓] Manual script run - completed (${result.timeElapsed}s)`);
+
+    if (alreadyUpToDate) {
+      await printInfo('   Already up to date.\n');
+
+      return;
+    }
+
+    // Completed migrations.
+    for (const item of list) {
+      await printLine(cyan(`       - ${item}`));
+    }
+
+    await printInfo(`   Ran ${list.length} scripts.\n`);
+  };
+
+  /**
+   * Failure handler.
+   */
+  onFailed = async (result: OperationResult) => {
+    await printLine(bold(red(`   [✓] Manual script run - Failed\n`)));
+  };
+
+  /**
+   * CLI command execution handler.
+   *
+   * @returns {Promise<void>}
+   */
+  async run(): Promise<void> {
+    const { flags: parsedFlags } = this.parse(RunScript);
+    const isDryRun = parsedFlags['dry-run'];
+    const config = await loadConfig(parsedFlags.config);
+
+    const connections = await resolveConnections(config, parsedFlags['connection-resolver']);
+
+    if (isDryRun) await printLine(magenta('\n• DRY RUN STARTED\n'));
+
+    const results = await runScriptAPI(config, connections, {
+      ...parsedFlags,
+      onStarted: this.onStarted,
+      onSuccess: this.onSuccess,
+      onFailed: this.onFailed
+    });
+
+    const failedCount = results.filter(({ success }) => !success).length;
+
+    if (failedCount === 0) {
+      if (isDryRun) await printLine(magenta('• DRY RUN ENDED\n'));
+
+      return process.exit(0);
+    }
+
+    printError(`Error: Migration failed for ${failedCount} connection(s).`);
+
+    if (isDryRun) await printLine(magenta('\n• DRY RUN ENDED\n'));
+
+    process.exit(-1);
+  }
+}
+
+export default RunScript;

--- a/src/commands/run-script.ts
+++ b/src/commands/run-script.ts
@@ -8,17 +8,17 @@ import { printLine, printError, printInfo } from '../util/io';
 import OperationResult from '../domain/operation/OperationResult';
 
 class RunScript extends Command {
-  static description = 'Run the migrations up to the latest changes.';
+  static description = 'Run the provided manual scripts.';
 
   static flags = {
-    'dry-run': flags.boolean({ description: 'Dry run migration.', default: false }),
+    'dry-run': flags.boolean({ description: 'Dry run script.', default: false }),
     only: flags.string({
       helpValue: 'CONNECTION_ID(s)',
       description: 'Filter provided connection(s). Comma separated ids eg: id1,id2'
     }),
     file: flags.string({
       helpValue: 'PATH',
-      description: 'Path to the manual SQL query'
+      description: 'Path to the manual SQL/JS/TS script'
     }),
     'connection-resolver': flags.string({
       helpValue: 'PATH',

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,16 @@ export function getSqlBasePath(config: Configuration): string {
 }
 
 /**
+ * Get manual scripts path from config.
+ *
+ * @param {Configuration} config
+ * @returns {string}
+ */
+export function getManualSqlBasePath(config: Configuration): string {
+  return path.join(config.basePath, config.manual.directory);
+}
+
+/**
  * Load config yaml file.
  *
  * @returns {Promise<Configuration>}

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export function getSqlBasePath(config: Configuration): string {
  * @param {Configuration} config
  * @returns {string}
  */
-export function getManualSqlBasePath(config: Configuration): string {
+export function getManualScriptBasePath(config: Configuration): string {
   return path.join(config.basePath, config.manual.directory);
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,10 @@ export const DEFAULT_CONFIG: Configuration = {
     directory: 'migration',
     tableName: 'knex_migrations', // Note: This is Knex's default value. Just keeping it same.
     sourceType: 'sql'
+  },
+  manual: {
+    directory: 'manual',
+    tableName: 'manual_scripts'
   }
 };
 

--- a/src/domain/Configuration.ts
+++ b/src/domain/Configuration.ts
@@ -20,6 +20,10 @@ interface Configuration {
     tableName: string;
     sourceType: 'sql' | 'javascript' | 'typescript';
   };
+  manual: {
+    directory: string;
+    tableName: string;
+  };
 }
 
 export default Configuration;

--- a/src/domain/RunScriptContext.ts
+++ b/src/domain/RunScriptContext.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+import { RunScriptParams } from './RunScriptParams';
+import OperationContext from './operation/OperationContext';
+
+export interface RunScriptContext extends OperationContext {
+  params: RunScriptParams;
+  migrateFunc: (
+    trx: Knex.Transaction,
+    files: any[],
+    connectionId: string,
+    runSQLScripts: (trx: Knex.Transaction, filteredScripts: string[]) => Promise<void>
+  ) => Promise<any>;
+}

--- a/src/domain/RunScriptContext.ts
+++ b/src/domain/RunScriptContext.ts
@@ -7,8 +7,8 @@ export interface RunScriptContext extends OperationContext {
   params: RunScriptParams;
   migrateFunc: (
     trx: Knex.Transaction,
-    files: any[],
+    files: string[],
     connectionId: string,
     runSQLScripts: (trx: Knex.Transaction, filteredScripts: string[]) => Promise<void>
-  ) => Promise<any>;
+  ) => Promise<(number | string[])[]>;
 }

--- a/src/domain/RunScriptParams.ts
+++ b/src/domain/RunScriptParams.ts
@@ -1,0 +1,5 @@
+import OperationParams from './operation/OperationParams';
+
+export interface RunScriptParams extends OperationParams {
+  file?: string;
+}

--- a/src/migration/service/knexMigrator.ts
+++ b/src/migration/service/knexMigrator.ts
@@ -123,3 +123,17 @@ export function getMigrationPath(config: Configuration): string {
 
   return migrationPath;
 }
+
+/**
+ * Get manual scripts directory path.
+ *
+ * @param {Configuration} config
+ * @returns {string}
+ */
+export function getManualScriptPath(config: Configuration): string {
+  const { basePath, manual } = config;
+
+  const scriptPath = path.isAbsolute(manual.directory) ? manual.directory : path.join(basePath, manual.directory);
+
+  return scriptPath;
+}

--- a/src/service/sqlRunner.ts
+++ b/src/service/sqlRunner.ts
@@ -8,7 +8,7 @@ import SqlCode from '../domain/SqlCode';
 import { dbLogger } from '../util/logger';
 import * as promise from '../util/promise';
 import SqlFileInfo from '../domain/SqlFileInfo';
-import { getManualSqlBasePath } from '../config';
+import { getManualScriptBasePath } from '../config';
 import { DROP_ONLY_OBJECT_TERMINATOR } from '../constants';
 import DatabaseObjectTypes from '../enum/DatabaseObjectTypes';
 import { RunScriptContext } from '../domain/RunScriptContext';
@@ -275,7 +275,7 @@ export async function runSQLScripts(
   connectionId: string,
   filteredScripts: string[]
 ) {
-  const sqlBasePath = getManualSqlBasePath(context.config);
+  const sqlBasePath = getManualScriptBasePath(context.config);
 
   const sqlScripts = await resolveFiles(sqlBasePath, manualSql);
 

--- a/src/service/sqlRunner.ts
+++ b/src/service/sqlRunner.ts
@@ -208,7 +208,6 @@ async function getFilteredScriptsToRun(trx: Knex.Transaction, files: string[], t
  * @param {string[]} files
  * @param {string} connectionId
  * @param {string} tableName
- * @param {any} callback
  * @returns {Promise<OperationResult[]>}
  */
 export async function runScriptWithLog(
@@ -216,7 +215,7 @@ export async function runScriptWithLog(
   files: string[],
   connectionId: string,
   tableName: string,
-  callback: any
+  callback: (t: Knex.Transaction, filteredScript: string[]) => Promise<void>
 ) {
   const log = dbLogger(connectionId);
 

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -152,7 +152,7 @@ export function copy(fromPath: string, toPath: string): Promise<void> {
 export function validateScriptFileName(filename: string): string {
   const ext = filename.split('.').pop();
 
-  if (!ext || ![FileExtensions.JS, FileExtensions.SQL, FileExtensions.JS].includes(ext as FileExtensions)) {
+  if (!ext || ![FileExtensions.TS, FileExtensions.SQL, FileExtensions.JS].includes(ext as FileExtensions)) {
     throw new Error('Invalid file name or extension');
   }
 

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
+import FileExtensions from '../enum/FileExtensions';
 
 export const mkdir = promisify(fs.mkdir);
 export const readDir = promisify(fs.readdir);
@@ -140,4 +141,20 @@ export function copy(fromPath: string, toPath: string): Promise<void> {
       return resolve();
     });
   });
+}
+
+/**
+ * Validate the script filename provided from CLI.
+ *
+ * @param {string} filename
+ * @returns {string}
+ */
+export function validateScriptFileName(filename: string): string {
+  const ext = filename.split('.').pop();
+
+  if (!ext || ![FileExtensions.JS, FileExtensions.SQL, FileExtensions.JS].includes(ext as FileExtensions)) {
+    throw new Error('Invalid file name or extension');
+  }
+
+  return filename;
 }

--- a/test/cli/commands/run-script.test.ts
+++ b/test/cli/commands/run-script.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import { it, describe } from 'mocha';
+
+import { runCli } from './util';
+import { mkdtempSync } from '../../../src/util/fs';
+
+const cwd = mkdtempSync();
+
+describe('CLI: Run script', () => {
+  describe('--help', () => {
+    it('should print help message.', async () => {
+      const { stdout } = await runCli(['run-script', '--help'], { cwd });
+
+      expect(stdout).contains('manual scripts');
+      expect(stdout).contains(`USAGE\n  $ sync-db run-script`);
+    });
+  });
+});

--- a/test/unit/service/sqlRunner.test.ts
+++ b/test/unit/service/sqlRunner.test.ts
@@ -69,4 +69,14 @@ describe('SERVICE: sqlRunner', () => {
       expect(() => sqlRunner.getDropStatement('views', 'test.hello_world')).to.throw(Error);
     });
   });
+
+  describe('getFileDetailsByExtension()', () => {
+    it('should return file details with extention', () => {
+      expect(sqlRunner.getFileDetailsByExtension('test.sql')).to.deep.equal({
+        extension: 'sql',
+        fileNames: ['test.sql'],
+        fileRelativePaths: ['sql/test.sql']
+      });
+    });
+  });
 });

--- a/test/unit/util/config.test.ts
+++ b/test/unit/util/config.test.ts
@@ -6,7 +6,14 @@ import { it, describe } from 'mocha';
 import { mkdtemp, write } from '../../../src/util/fs';
 import Configuration from '../../../src/domain/Configuration';
 import ConnectionConfig from '../../../src/domain/ConnectionConfig';
-import { validate, getConnectionId, resolveConnectionsFromEnv, isCLI, loadConfig } from '../../../src/config';
+import {
+  validate,
+  getConnectionId,
+  resolveConnectionsFromEnv,
+  isCLI,
+  loadConfig,
+  getManualScriptBasePath
+} from '../../../src/config';
 
 describe('CONFIG:', () => {
   describe('isCLI', () => {
@@ -212,6 +219,26 @@ describe('CONFIG:', () => {
       process.chdir(cwd);
       const config = await loadConfig(path.join(cwd, 'sync-db-test.yml'));
       expect(config).to.have.property('migration');
+    });
+  });
+
+  describe('getManualScriptBasePath', () => {
+    it('should resolve correct manual script base path.', async () => {
+      const cwd = await mkdtemp();
+      await write(
+        path.join(cwd, 'sync-db.yml'),
+        yaml.stringify({
+          basePath: 'src',
+          manual: {
+            directory: 'manual',
+            tableName: 'manual_script_logs'
+          }
+        } as Configuration)
+      );
+
+      process.chdir(cwd);
+      const config = await loadConfig();
+      expect(getManualScriptBasePath(config)).to.eq('src/manual');
     });
   });
 });

--- a/test/unit/util/fs.test.ts
+++ b/test/unit/util/fs.test.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import { it, describe } from 'mocha';
 
-import { write, read, remove, exists, mkdtemp, glob, existsDir } from '../../../src/util/fs';
+import { write, read, remove, exists, mkdtemp, glob, existsDir, validateScriptFileName } from '../../../src/util/fs';
 
 describe('UTIL: fs', () => {
   let filePath: string;
@@ -112,6 +112,30 @@ describe('UTIL: fs', () => {
       const result = await glob(tmp2);
 
       expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('validateScriptFileName', () => {
+    it('should throw error for invalid file name', async () => {
+      return expect(() => validateScriptFileName('test')).to.throw('Invalid file name or extension');
+    });
+
+    it('should support only JS/TS or SQL script', () => {
+      const fname0 = validateScriptFileName('test.sql');
+      const fname1 = validateScriptFileName('test.js');
+      const fname2 = validateScriptFileName('test.ts');
+
+      assert(fname0 === 'test.sql');
+      assert(fname1 === 'test.js');
+      assert(fname2 === 'test.ts');
+
+      expect(() => validateScriptFileName('test.c')).to.throw('Invalid file name or extension');
+    });
+
+    it('should return filename if validation is successfull', () => {
+      const fname = validateScriptFileName('test.sql');
+
+      return expect(fname).to.eq('test.sql');
     });
   });
 });


### PR DESCRIPTION
## Changes

- Introduce new command `run-script`
- Accepts `--file` as flag
- Can be used to run manual scripts in JS/TS or SQL
- For SQl, simply run the script present in the given file
- For JS/TS, a function `main` is expected to be exported which gets knex connection and identifier as args. example
```
export async function main(conn: Knex.Transaction, id: string) {
  await conn.......

  log(`Completed script for ${id}`)
}
```
- Other existing flags like `--only` -> to run script for specific connection and `--dry-run` -> to dry run the script works as usual
- Update unit tests

## Todo
- Update readme
- Add demo ss

