### PR TITLE
Handle the invalid command resulting in infinite loop

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,1 +1,27 @@
+// This script checks if the command-line argument provided is one of the available commands.
+// If the command is not recognized, it prints an error message and exits the process.
+import { printError } from '../util/io';
+
+(async () => {
+  const availableCommands = [
+    '--help',
+    'make-publish',
+    'make',
+    'migrate-latest',
+    'migrate-list',
+    'migrate-rollback',
+    'prune',
+    'synchronize',
+    '--version'
+  ];
+
+  // Check if there are at least 3 arguments (node, script, command)
+  // and if the command is not in the list of available commands
+  if (process.argv.length >= 3 && !availableCommands.includes(process.argv[2])) {
+    await printError(`Invalid command. Please use one of the following commands: ${availableCommands.join(', ')}`);
+    // Exit the process with a status code of 1 (indicating an error)
+    process.exit(1);
+  }
+})();
+
 export { run } from '@oclif/command';


### PR DESCRIPTION
## Changes

- Check if the command provided to sync-db in valid one 
- Show the available command in case of invalid entry

- Fixes the infinite loop while unknown command is given to sync-db

## Test

### Before

`DEBUG=* yarn sync-db gg`
![image](https://github.com/user-attachments/assets/19179416-849e-40af-9cec-5d95c0328dcf)


### After

`DEBUG=* yarn sync-db gg`

![image](https://github.com/user-attachments/assets/3c09eccd-6964-45a0-8311-8fbc9889815d)

